### PR TITLE
Bump Go to 1.17.0 and golangci-lint to v1.42.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.13.15-buster
+FROM golang:1.17.0-bullseye
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
@@ -10,18 +10,17 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         gnupg \
-    && rm -rf /var/lib/apt/lists/*; \
-    \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - >/dev/null; \
-    echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian buster stable" > /etc/apt/sources.list.d/docker.list; \
-    \
-    apt-get update -qq && apt-get install -y --no-install-recommends \
-        docker-ce=5:20.10.* \
+        lsb-release \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update -qq && apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io \
     && rm -rf /var/lib/apt/lists/*
 
 ## install golangci
 RUN if [ "${ARCH}" = "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.27.0; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.42.0; \
     fi
 
 # -- for dapper


### PR DESCRIPTION
There is no reason to stick to an archived version.