### PR TITLE
Add harvester os-collector

### DIFF
--- a/hack/collector-harvesteros
+++ b/hack/collector-harvesteros
@@ -1,0 +1,30 @@
+#!/bin/bash -ux
+
+HOST_PATH=$1
+BUNDLE_DIR=$2
+
+cd ${BUNDLE_DIR}
+# get some host information
+cp ${HOST_PATH}/etc/hostname .
+
+###############################################################################
+# collect configs
+###############################################################################
+mkdir -p configs
+cp -r /host/oem configs
+
+###############################################################################
+# collect logs
+###############################################################################
+mkdir -p logs
+cd logs
+
+chroot $HOST_PATH /usr/bin/journalctl -k > kernel.log
+
+units=(rke2-server rke2-agent rancherd rancher-system-agent wicked iscsid)
+
+for unit in ${units[@]}; do
+    chroot $HOST_PATH /usr/bin/journalctl -b all -u $unit | tail -c 10m > $unit.log
+done
+
+cp ${HOST_PATH}/var/log/console.log .

--- a/hack/collector-k3os
+++ b/hack/collector-k3os
@@ -1,0 +1,22 @@
+#!/bin/bash -ux
+
+HOST_PATH=$1
+BUNDLE_DIR=$2
+
+cd ${BUNDLE_DIR}
+
+# get some host information
+cp ${HOST_PATH}/etc/hostname .
+
+# collect logs
+mkdir -p logs
+cd logs
+dmesg &> dmesg.log
+
+# k3s logs don't rorate well and can be huge
+tail -c 10m ${HOST_PATH}/var/log/k3s-service.log > k3s-service.log
+tail -c 10m ${HOST_PATH}/var/log/k3s-restarter.log > k3s-restarter.log
+
+cp ${HOST_PATH}/var/log/qemu-ga.log* .
+cp ${HOST_PATH}/var/log/messages* .
+cp ${HOST_PATH}/var/log/console.log .

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,10 +4,13 @@ RUN apk update && apk add -u --no-cache zip tini bash curl
 COPY package/entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 
-ADD bin/support-bundle-collector.sh /usr/bin
+ADD hack/support-bundle-collector.sh /usr/bin
 RUN chmod +x /usr/bin/support-bundle-collector.sh
 
 ADD bin/support-bundle-kit /usr/bin
 RUN chmod +x /usr/bin/support-bundle-kit
+
+ADD hack/collector-* /usr/bin/
+RUN chmod +x /usr/bin/collector-*
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -104,30 +104,18 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "hostetc",
-									MountPath: "/host/etc",
-								},
-								{
-									Name:      "hostlog",
-									MountPath: "/host/var/log",
+									Name:      "host",
+									MountPath: "/host",
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "hostetc",
+							Name: "host",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc",
-								},
-							},
-						},
-						{
-							Name: "hostlog",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/var/log",
+									Path: "/",
 								},
 							},
 						},

--- a/scripts/build
+++ b/scripts/build
@@ -17,4 +17,4 @@ if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
 fi
 
 # non-go scripts
-cp hack/*.sh bin
+cp hack/* bin

--- a/scripts/package
+++ b/scripts/package
@@ -6,8 +6,8 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p dist/artifacts
-cp bin/*.sh dist/artifacts
-cp bin/support-bundle-kit dist/artifacts/support-bundle-kit${SUFFIX}
+cp bin/* dist/artifacts
+mv dist/artifacts/support-bundle-kit dist/artifacts/support-bundle-kit${SUFFIX}
 
 IMAGE=${REPO}/support-bundle-kit:${TAG}
 DOCKERFILE=Dockerfile


### PR DESCRIPTION
- Select os-collector based on OS ID. Now supports both k3os and harvesteros.
- Mount the whole host root directory into pod.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>