### PR TITLE
Support specifying nodeSelector of agent DaemonSet

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -40,5 +40,5 @@ func init() {
 	managerCmd.PersistentFlags().StringVar(&sbm.ManagerPodIP, "manager-pod-ip", os.Getenv("SUPPORT_BUNDLE_MANAGER_POD_IP"), "The support bundle manager's IP (pod runs this app)")
 	managerCmd.PersistentFlags().StringVar(&sbm.ImageName, "image-name", os.Getenv("SUPPORT_BUNDLE_IMAGE"), "The support bundle image")
 	managerCmd.PersistentFlags().StringVar(&sbm.ImagePullPolicy, "image-pull-policy", os.Getenv("SUPPORT_BUNDLE_IMAGE_PULL_POLICY"), "Pull policy of the support bundle image")
-
+	managerCmd.PersistentFlags().StringVar(&sbm.NodeSelector, "node-selector", os.Getenv("SUPPORT_BUNDLE_NODE_SELECTOR"), "NodeSelector of agent DaemonSet. e.g., key1=value1,key2=value2")
 }

--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -66,7 +66,7 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 					},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{"node-role.kubernetes.io/worker": types.SupportBundleNodeLabelValue},
+					NodeSelector: a.sbm.getNodeSelector(),
 					Tolerations: []corev1.Toleration{
 						{
 							Key:   types.DrainKey,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -14,9 +14,8 @@ const (
 	SupportBundleStateError      = SupportBundleState("error")
 
 	// labels
-	SupportBundleLabelKey       = "rancher/supportbundle"
-	SupportBundleNodeLabelValue = "true"
-	DrainKey                    = "kubevirt.io/drain"
+	SupportBundleLabelKey = "rancher/supportbundle"
+	DrainKey              = "kubevirt.io/drain"
 
 	SupportBundleManager = "support-bundle-manager"
 	SupportBundleAgent   = "support-bundle-agent"


### PR DESCRIPTION
Specify strings like `key1=value1,key2=value2` in `SUPPORT_BUNDLE_NODE_SELECTOR` env variable or `--node-selector` flag to ensure the agent DaemonSet pods are only run on certain nodes.

It's a short-term solution.

Ideally, we can have a similar match expression like SUC:
https://github.com/rancher/system-upgrade-controller/blob/32a31b23226239802348a4b7ab3dbfcb06f983e1/examples/k3s-upgrade.yaml#L38-L44