### PR TITLE
Fix API throttling to speed up the bundle generation

### DIFF
--- a/pkg/manager/cluster.go
+++ b/pkg/manager/cluster.go
@@ -85,9 +85,17 @@ func (c *Cluster) generateSupportBundleYAMLs(yamlsDir string, errLog io.Writer) 
 	// Namespaced scope: all resources
 	namespaces := []string{"default", "kube-system", "cattle-system"}
 	namespaces = append(namespaces, c.sbm.Namespaces...)
+
+	done := make(map[string]struct{})
 	for _, namespace := range namespaces {
+		if _, ok := done[namespace]; ok {
+			continue
+		}
+
 		namespacedDir := filepath.Join(yamlsDir, "namespaced", namespace)
 		c.generateDiscoveredNamespacedYAMLs(namespace, namespacedDir, errLog)
+
+		done[namespace] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
- Increase the Burst and QPS values of DiscoveryClient (now defaults to 10000). The cluster resource collecting phase time is reduced from 3 mins to 23 secs in my cluster)
- The client code might specify a namespace that's already defined in our default ones (`"default", "kube-system", "cattle-system"`). Do not process a namespace twice if that's already processed.



Fix https://github.com/rancher/support-bundle-kit/issues/14.

References:
- The [Burst and QPS values adjusted in the discovery client](https://github.com/kubernetes/kubernetes/pull/86168/files#diff-14f541e7356b7bc7f735b24db888b48b81b81e136b5af2925e912b95889dd010) are not large enough for our use case.
- [Some implementations](https://github.com/voyagermesh/voyager/issues/640#issuecomment-337450743) increase the values up to `1e6`
