### PR TITLE
Skip unreachable node during collecting NodeBundles

### DIFF
--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -72,6 +72,11 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 							Key:   types.DrainKey,
 							Value: "scheduling",
 						},
+						{
+							Key:      corev1.TaintNodeUnschedulable,
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
 					},
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
We currently skip nodes with unavailable network and not ready kubelet. 
Nodes tainted with `node.kubernetes.io/unschedulable:NoSchedule` are tolerated.

Related issue: https://github.com/harvester/harvester/issues/1524

Any improvement is welcome.