### PR TITLE
Support excluding resources out from packaging into support bundle.

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -50,4 +50,5 @@ func init() {
 	managerCmd.PersistentFlags().StringVar(&sbm.ImageName, "image-name", os.Getenv("SUPPORT_BUNDLE_IMAGE"), "The support bundle image")
 	managerCmd.PersistentFlags().StringVar(&sbm.ImagePullPolicy, "image-pull-policy", os.Getenv("SUPPORT_BUNDLE_IMAGE_PULL_POLICY"), "Pull policy of the support bundle image")
 	managerCmd.PersistentFlags().StringVar(&sbm.NodeSelector, "node-selector", os.Getenv("SUPPORT_BUNDLE_NODE_SELECTOR"), "NodeSelector of agent DaemonSet. e.g., key1=value1,key2=value2")
+	managerCmd.PersistentFlags().StringSliceVar(&sbm.ExcludeResourceList, "exclude-resources", getEnvStringSlice("SUPPORT_BUNDLE_EXCLUDE_RESOURCES"), "List of resources to exclude. e.g., settings.harvesterhci.io,secrets")
 }

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rancher/support-bundle-kit/pkg/manager"
 	"github.com/spf13/cobra"
@@ -32,9 +33,17 @@ And it also waits for reports from support bundle agents. The reports contain:
 	},
 }
 
+func getEnvStringSlice(key string) []string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return []string{}
+	}
+	return strings.Split(value, ",")
+}
+
 func init() {
 	rootCmd.AddCommand(managerCmd)
-	managerCmd.PersistentFlags().StringVar(&sbm.NamespaceList, "namespaces", os.Getenv("SUPPORT_BUNDLE_TARGET_NAMESPACES"), "List of namespaces delimited by ,")
+	managerCmd.PersistentFlags().StringSliceVar(&sbm.Namespaces, "namespaces", getEnvStringSlice("SUPPORT_BUNDLE_TARGET_NAMESPACES"), "List of namespaces delimited by ,")
 	managerCmd.PersistentFlags().StringVar(&sbm.BundleName, "bundlename", os.Getenv("SUPPORT_BUNDLE_NAME"), "The support bundle name")
 	managerCmd.PersistentFlags().StringVar(&sbm.OutputDir, "outdir", os.Getenv("SUPPORT_BUNDLE_OUTPUT_DIR"), "The directory to store the bundle")
 	managerCmd.PersistentFlags().StringVar(&sbm.ManagerPodIP, "manager-pod-ip", os.Getenv("SUPPORT_BUNDLE_MANAGER_POD_IP"), "The support bundle manager's IP (pod runs this app)")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -25,7 +25,6 @@ import (
 
 type SupportBundleManager struct {
 	Namespaces      []string
-	NamespaceList   string
 	BundleName      string
 	bundleFileName  string
 	OutputDir       string
@@ -141,8 +140,6 @@ func (m *SupportBundleManager) Run() error {
 }
 
 func (m *SupportBundleManager) phaseInit() error {
-	m.Namespaces = strings.Split(m.NamespaceList, ",")
-
 	if err := m.check(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Arg `--exclude-resources` (env `SUPPORT_BUNDLE_EXCLUDE_RESOURCES`)
accepts a comma-separated list of `<resource-name>.<group>` qualified
name of resources. Mainly serves to exclude matched resources out from
packaging into support bundle.

At this moment, only `secrets` resource is excluded by default.