### PR TITLE
Remove sensitive data in configs and collect rancher configs

### DIFF
--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -3,15 +3,75 @@
 HOST_PATH=$1
 BUNDLE_DIR=$2
 
+log_warn() {
+    echo "[WARNING] $1"
+}
+
+remove_yaml_secret() {
+    local yaml_file=$1
+    export CONFIG_HEADER_COMMENT="Note: this file is re-formatted by support-bundle-kit collector."
+
+    yq e '. headComment=strenv(CONFIG_HEADER_COMMENT)' $yaml_file -i
+    yq e '(.. | select(has("passwd")) | .passwd) = "***" ' $yaml_file -i
+    yq e '(.. | select(has("password")) | .password) = "***" ' $yaml_file -i
+    yq e '(.. | select(has("secret")) | .secret) = "***" ' $yaml_file -i
+    yq e '(.. | select(has("token")) | .token) = "***" ' $yaml_file -i
+    yq e '(.. | select(has("agent-token")) | .agent-token) = "***" ' $yaml_file -i
+
+    unset CONFIG_HEADER_COMMENT
+}
+
+collect_etc() {
+    local to_dir=$1
+    local config
+
+    cp ${HOST_PATH}/etc/hostname $to_dir
+    cp ${HOST_PATH}/etc/os-release $to_dir
+    cp ${HOST_PATH}/etc/harvester-release.yaml $to_dir
+
+    mkdir -p $to_dir/rancher
+    cp -r ${HOST_PATH}/etc/rancher/agent $to_dir/rancher/
+    cp -r ${HOST_PATH}/etc/rancher/installer $to_dir/rancher/
+    cp -r ${HOST_PATH}/etc/rancher/rancherd $to_dir/rancher/ && chmod -R 744 $to_dir/rancher/rancherd
+    cp -r ${HOST_PATH}/etc/rancher/rke2 $to_dir/rancher/ && chmod -R 744 $to_dir/rancher/rke2/config.yaml.d
+
+    for config in $(find $to_dir/rancher -type f -regex ".*\.\(yaml\|yml\)"); do
+        remove_yaml_secret $config
+    done
+
+    rm -f $to_dir/rancher/rke2/rke2.yaml
+}
+
+remove_oem_secrets() {
+    local oem_dir=$1
+    local header=""
+    local config
+
+
+    if [ ! -d $oem_dir ]; then
+        log_warn "OEM folder $oem_dir doesn't exist."
+        return
+    fi
+
+    for config in $(find $oem_dir -type f -regex ".*\.\(yaml\|yml\|config\)"); do
+        remove_yaml_secret $config
+    done
+
+    # remove token in file contents
+    sed -i 's/token:.*/token: '\''***'\''/' $oem_dir/99_custom.yaml
+}
+
 cd ${BUNDLE_DIR}
-# get some host information
-cp ${HOST_PATH}/etc/hostname .
+
 
 ###############################################################################
 # collect configs
 ###############################################################################
-mkdir -p configs
-cp -r /host/oem configs
+mkdir -p ${BUNDLE_DIR}/configs
+cp -r $HOST_PATH/oem ${BUNDLE_DIR}/configs
+remove_oem_secrets ${BUNDLE_DIR}/configs/oem
+mkdir -p ${BUNDLE_DIR}/configs/etc
+collect_etc ${BUNDLE_DIR}/configs/etc
 
 ###############################################################################
 # collect logs

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-RUN apk update && apk add -u --no-cache zip tini bash curl
+RUN apk update && apk add -u --no-cache zip tini bash curl yq
 
 COPY package/entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh


### PR DESCRIPTION
Fix https://github.com/rancher/support-bundle-kit/issues/28.

Add configs under `/etc/rancher`:
```
➜  node1 pwd
/Users/kiefer/Downloads/supportbundle_a968c64f-604a-4bce-9ed1-d2bee6fe58fc_2022-01-12T16-03-41Z/nodes/node1
➜  node1 find configs
configs/etc
configs/etc/harvester-release.yaml
configs/etc/hostname
configs/etc/rancher
configs/etc/rancher/rke2
configs/etc/rancher/rke2/config.yaml.d
configs/etc/rancher/rke2/config.yaml.d/40-rancherd.yaml
configs/etc/rancher/rke2/config.yaml.d/50-rancher.yaml
configs/etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml
configs/etc/rancher/rke2/config.yaml.d/90-harvester-agent.yaml
configs/etc/rancher/agent
configs/etc/rancher/agent/cattle-id
configs/etc/rancher/agent/config.yaml
configs/etc/rancher/rancherd
configs/etc/rancher/rancherd/config.yaml
configs/etc/rancher/rancherd/config.yaml.d
configs/etc/rancher/rancherd/config.yaml.d/12-monitoring-dashboard.yaml
configs/etc/rancher/rancherd/config.yaml.d/20-harvester-settings.yaml
configs/etc/rancher/rancherd/config.yaml.d/10-harvester.yaml
configs/etc/rancher/rancherd/config.yaml.d/11-monitoring-crd.yaml
configs/etc/rancher/rancherd/config.yaml.d/13-monitoring.yaml
configs/etc/rancher/installer
configs/etc/rancher/installer/env
configs/etc/os-release
configs/oem
configs/oem/harvester.config
configs/oem/lost+found
configs/oem/99_custom.yaml
```

Passwords and tokens are hidden:
```
➜  node1 grep token configs/* -R
configs/etc/rancher/rke2/config.yaml.d/40-rancherd.yaml:token: '***'
configs/etc/rancher/rke2/config.yaml.d/50-rancher.yaml:{"agent-token": "***", "cni": "calico", "kube-controller-manager-arg": ["cert-dir=/var/lib/rancher/rke2/server/tls/kube-controller-manager", "secure-port=10257"], "kube-controller-manager-extra-mount": ["/var/lib/rancher/rke2/server/tls/kube-controller-manager:/var/lib/rancher/rke2/server/tls/kube-controller-manager"], "kube-scheduler-arg": ["cert-dir=/var/lib/rancher/rke2/server/tls/kube-scheduler", "secure-port=10259"], "kube-scheduler-extra-mount": ["/var/lib/rancher/rke2/server/tls/kube-scheduler:/var/lib/rancher/rke2/server/tls/kube-scheduler"], "node-label": ["rke.cattle.io/machine=1cea937d-1b49-4955-9dbe-5477bd757793"], "token": "***"}
configs/etc/rancher/rancherd/config.yaml:token: "***"
configs/oem/harvester.config:token: '***'
configs/oem/99_custom.yaml:            token: '***'
➜  node1 grep password configs/* -R
configs/oem/harvester.config:  password: '***'
➜  node1 grep passwd configs/* -R
configs/oem/99_custom.yaml:          passwd: '***'
```