### PR TITLE
Fix not able schedule an agent to a draining node

### DIFF
--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -69,8 +69,8 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 					NodeSelector: a.sbm.getNodeSelector(),
 					Tolerations: []corev1.Toleration{
 						{
-							Key:   types.DrainKey,
-							Value: "scheduling",
+							Key:      types.KubevirtDrainKey,
+							Operator: corev1.TolerationOpExists,
 						},
 						{
 							Key:      corev1.TaintNodeUnschedulable,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,7 +15,7 @@ const (
 
 	// labels
 	SupportBundleLabelKey = "rancher/supportbundle"
-	DrainKey              = "kubevirt.io/drain"
+	KubevirtDrainKey      = "kubevirt.io/drain"
 
 	SupportBundleManager = "support-bundle-manager"
 	SupportBundleAgent   = "support-bundle-agent"


### PR DESCRIPTION
This was observed when collecting supportbundle during a upgrade.
The taint prevents agent to be scheduled on the draining node:

```
- effect: NoSchedule
    key: kubevirt.io/drain
    value: draining
```

The change allows agent daemon set to be scheduled on draining nodes.
