### PR TITLE
Fix leaking file handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# editors
+.idea
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -277,7 +277,10 @@ func (m *SupportBundleManager) collectNodeBundles() error {
 }
 
 func (m *SupportBundleManager) verifyNodeBundle(file string) error {
-	_, err := zip.OpenReader(file)
+	f, err := zip.OpenReader(file)
+	if err == nil {
+		_ = f.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
Since zip.OpenReader returns a ReadCloser it is the users responsibility
to close this when no longer needed, otherwise the file handle will be 
leaked.