### PR TITLE
fix(simulator): API server service cluster IP range

### DIFF
--- a/pkg/simulator/apiserver/apiserver.go
+++ b/pkg/simulator/apiserver/apiserver.go
@@ -16,6 +16,10 @@ import (
 	"net"
 )
 
+const (
+	DefaultServiceClusterIP = "10.53.0.1"
+)
+
 type APIServerConfig struct {
 	Certs      *certs.CertInfo
 	Etcd       *etcd.EtcdConfig
@@ -29,7 +33,7 @@ const (
 
 // RunAPIServer will bootstrap an API server with only core resources enabled
 // No additional controllers will be scheduled
-func (a *APIServerConfig) RunAPIServer(ctx context.Context) error {
+func (a *APIServerConfig) RunAPIServer(ctx context.Context, serviceClusterIP string) error {
 	var err error
 	s := options.NewServerRunOptions()
 	s.Etcd.StorageConfig.Transport.ServerList = a.Etcd.Endpoints
@@ -41,9 +45,9 @@ func (a *APIServerConfig) RunAPIServer(ctx context.Context) error {
 		"v1":       "true",
 		"api/beta": "true",
 	}
-	s.ServiceClusterIPRanges = "10.53.0.1/16"
 	s.AllowPrivileged = true
 	s.ServiceAccountSigningKeyFile = a.Certs.ServiceAccountCertKey
+	s.ServiceClusterIPRanges = serviceClusterIP + "/16"
 	s.SecureServing.SecureServingOptions.ServerCert.CertKey.CertFile = a.Certs.APICert
 	s.SecureServing.SecureServingOptions.ServerCert.CertKey.KeyFile = a.Certs.APICertKey
 	s.SecureServing.SecureServingOptions.BindAddress = net.ParseIP("127.0.0.1")

--- a/pkg/simulator/apiserver/apiserver_test.go
+++ b/pkg/simulator/apiserver/apiserver_test.go
@@ -41,7 +41,7 @@ func TestRunAPIServer(t *testing.T) {
 		t.Fatalf("error generating kubeconfig %v", err)
 	}
 
-	err = a.RunAPIServer(ctx)
+	err = a.RunAPIServer(ctx, DefaultServiceClusterIP)
 	if err != nil {
 		t.Fatalf("error running API Server %v", err)
 	}

--- a/pkg/simulator/crd/crd_test.go
+++ b/pkg/simulator/crd/crd_test.go
@@ -57,7 +57,7 @@ func TestInstallCRD(t *testing.T) {
 
 	eg, egctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return a.RunAPIServer(egctx)
+		return a.RunAPIServer(egctx, apiserver.DefaultServiceClusterIP)
 	})
 
 	eg.Go(func() error {

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	eg.Go(func() error {
-		return a.RunAPIServer(egctx)
+		return a.RunAPIServer(egctx, apiserver.DefaultServiceClusterIP)
 	})
 
 	// run fake kubelet


### PR DESCRIPTION
The current [hardcoded service cluster IP](https://github.com/rancher/support-bundle-kit/blob/master/pkg/simulator/apiserver/apiserver.go#L44) range can cause services to fail to start when its cluster IP is not within the range.
```
time="2022-10-28T07:31:53Z" level=error msg="error during creation of resource metrics-server with gvr /v1, Resource=services" error="Service \"metrics-server\" is invalid: spec.clusterIPs: Invalid value: []string{\"10.43.157.71\"}: failed to allocated ip:10.43.157.71 with error:provided IP is not in the valid range. The range of valid IPs is 10.53.0.0/16"
```

Propose to use the service cluster IP from the support bundle for the API server cluster IP range.

https://github.com/longhorn/longhorn/issues/2759