### PR TITLE
fix to handle camel case in titles

### DIFF
--- a/pkg/manager/client/discovery.go
+++ b/pkg/manager/client/discovery.go
@@ -78,10 +78,7 @@ func toObj(b []byte, groupVersion, kind string) (interface{}, error) {
 			return nil, err
 		}
 
-		// strings.Title deprecated in go1.18
-		// switching over to golang.org/x/text/cases
-		c := cases.Title(language.English)
-		if _, err = child.SetP(c.String(kind), "kind"); err != nil {
+		if _, err = child.SetP(toTitle(kind), "kind"); err != nil {
 			logrus.Error("Unable to set kind field.")
 			return nil, err
 		}
@@ -219,4 +216,9 @@ func (dc *DiscoveryClient) ResourcesForCluster(exclude ExcludeFilter, errLog io.
 	}
 
 	return objs, nil
+}
+
+func toTitle(kind string) string {
+	c := cases.Title(language.English, cases.NoLower)
+	return c.String(kind)
 }

--- a/pkg/manager/client/discovery_test.go
+++ b/pkg/manager/client/discovery_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_toTitle(t *testing.T) {
+	kind := "CustomResourceDefinition"
+	assert := require.New(t)
+	assert.Equal(kind, toTitle(kind), "expected kind to be same")
+}


### PR DESCRIPTION
PR introduces a small fix to stop the conversion of "kind" to lowercase in exported objects.

This is currently resulting in support bundles with incorrect kind format, which is breaking simulator functionality.

For example:

```
FATA[0007] error loading cluster scoped objects error looking up GVR no matches for kind "Customresourcedefinition" in version "apiextensions.k8s.io/v1" for object &{map[apiVersion:apiextensions.k8s.io/v1 kind:Customresourcedefinition metadata:map[annotations:map[meta.helm.sh/release-name:harvester-crd meta.helm.sh/release-namespace:harvester-system objectset.rio.cattle.io/id:default-mcc-harvester-crd-cattle-fleet-local-system sim.harvesterhci.io/creationTimestamp:2022-11-07T09:24:16Z] creationTimestamp:2022-11-07T09:24:16Z generation:1 labels:map[app.kubernetes.io/managed-by:Helm objectset.rio.cattle.io/hash:d4a83267ddde6a8769c04362d4a0e5605db9baa7] managedFields:[map[apiVersion:apiextensions.k8s.io/v1 fieldsType:FieldsV1 fieldsV1:map[f:metadata:map[f:annotations:map[.:map[] f:meta.helm.sh/release-name:map[] f:meta.helm.sh/release-namespace:map[] f:objectset.rio.cattle.io/id:map[]] f:labels:map[.:map[] f:app.kubernetes.io/managed-by:map[] f:objectset.rio.cattle.io/hash:map[]]] f:spec:map[f:conversion:map[.:map[] f:strategy:map[]] f:group:map[] f:names:map[f:kind:map[] f:listKind:map[] f:plural:map[] f:singular:map[]] f:scope:map[] f:versions:map[]]] manager:fleetagent operation:Update time:2022-11-07T09:24:16Z] map[apiVersion:apiextensions.k8s.io/v1 fieldsType:FieldsV1 fieldsV1:map[f:status:map[f:acceptedNames:map[f:kind:map[] f:listKind:map[] f:plural:map[] f:singular:map[]] f:conditions:map[k:{"type":"Established"}:map[.:map[] f:lastTransitionTime:map[] f:message:map[] f:reason:map[] f:status:map[] f:type:map[]] k:{"type":"NamesAccepted"}:map[.:map[] f:lastTransitionTime:map[] f:message:map[] f:reason:map[] f:status:map[] f:type:map[]]]]] manager:kube-apiserver operation:Update subresource:status time:2022-11-07T09:24:16Z]] name:addons.harvesterhci.io uid:aade2707-1de9-449c-8b68-f9a53d4bf357] spec:map[conversion:map[strategy:None] group:harvesterhci.io names:map[kind:Addon listKind:AddonList plural:addons singular:addon] scope:Namespaced versions:[map[additionalPrinterColumns:[map[jsonPath:.spec.repo name:HelmRepo type:string] map[jsonPath:.spec.chart name:ChartName type:string] map[jsonPath:.spec.enabled name:Enabled type:boolean]] name:v1beta1 schema:map[openAPIV3Schema:map[properties:map[apiVersion:map[description:APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources type:string] kind:map[description:Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds type:string] metadata:map[type:object] spec:map[properties:map[chart:map[type:string] enabled:map[type:boolean] repo:map[type:string] valuesContent:map[type:string] version:map[type:string]] required:[chart enabled repo valuesContent version] type:object] status:map[properties:map[status:map[type:string]] type:object]] required:[spec] type:object]] served:true storage:true subresources:map[status:map[]]]]] status:map[acceptedNames:map[kind:Addon listKind:AddonList plural:addons singular:addon] conditions:[map[lastTransitionTime:2022-11-07T09:24:16Z message:no conflicts found reason:NoConflicts status:True type:NamesAccepted] map[lastTransitionTime:2022-11-07T09:24:16Z message:the initial names have been accepted reason:InitialNamesAccepted status:True type:Established]] storedVersions:[v1beta1]]]}

FATA[0060] error loading cluster scoped objects error looking up GVR no matches for kind "Clusterrepo" in version "catalog.cattle.io/v1" for object &{map[apiVersion:catalog.cattle.io/v1 kind:Clusterrepo metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"catalog.cattle.io/v1","kind":"ClusterRepo","metadata":{"annotations":{},"name":"harvester-charts"},"spec":{"url":"http://harvester-cluster-repo.cattle-system/charts"}}
 sim.harvesterhci.io/creationTimestamp:2022-11-07T09:24:07Z] creationTimestamp:2022-11-07T09:24:07Z generation:1 managedFields:[map[apiVersion:catalog.cattle.io/v1 fieldsType:FieldsV1 fieldsV1:map[f:metadata:map[f:annotations:map[.:map[] f:kubectl.kubernetes.io/last-applied-configuration:map[]]] f:spec:map[.:map[] f:url:map[]]] manager:kubectl-client-side-apply operation:Update time:2022-11-07T09:24:07Z] map[apiVersion:catalog.cattle.io/v1 fieldsType:FieldsV1 fieldsV1:map[f:status:map[.:map[] f:conditions:map[] f:downloadTime:map[] f:indexConfigMapName:map[] f:indexConfigMapNamespace:map[] f:observedGeneration:map[] f:url:map[]]] manager:rancher operation:Update subresource:status time:2022-11-07T09:24:10Z]] name:harvester-charts uid:fb08e737-00c8-43e7-9ceb-eac0deff31ab] spec:map[url:http://harvester-cluster-repo.cattle-system/charts] status:map[conditions:[map[lastUpdateTime:2022-11-07T09:24:07Z status:True type:FollowerDownloaded] map[lastUpdateTime:2022-11-09T07:21:54Z status:True type:Downloaded]] downloadTime:2022-11-09T07:21:54Z indexConfigMapName:harvester-charts-0-fb08e737-00c8-43e7-9ceb-eac0deff31ab indexConfigMapNamespace:cattle-system observedGeneration:1 url:http://harvester-cluster-repo.cattle-system/charts]]}
```