### PR TITLE
fix(agent-daemonset): tolerate all taints

### DIFF
--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -69,13 +69,7 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 					NodeSelector: a.sbm.getNodeSelector(),
 					Tolerations: []corev1.Toleration{
 						{
-							Key:      types.KubevirtDrainKey,
 							Operator: corev1.TolerationOpExists,
-						},
-						{
-							Key:      corev1.TaintNodeUnschedulable,
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
 						},
 					},
 					Containers: []corev1.Container{


### PR DESCRIPTION
Propose to have Agent DaemonSet respecting all taints to avoid getting blocked in node bundle collection. Because in Longhorn, we cannot predict and have no control over the node taints.

https://github.com/longhorn/longhorn/issues/2759