### PR TITLE
Make the previous logs of pods work correctly

### DIFF
--- a/pkg/manager/client/k8s.go
+++ b/pkg/manager/client/k8s.go
@@ -51,6 +51,29 @@ func (k *KubernetesClient) GetPodContainerLogRequest(namespace, podName, contain
 	})
 }
 
+func (k *KubernetesClient) GetPodContainerPreviousLogRequest(namespace, podName, containerName string) *rest.Request {
+	return k.clientSet.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container:  containerName,
+		Timestamps: true,
+		Previous:   true,
+	})
+}
+
+func (k *KubernetesClient) GetPodRestartCount(namespace, podName, containerName string) (int32, error) {
+	pod, err := k.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name != containerName {
+			continue
+		}
+		return containerStatus.RestartCount, nil
+	}
+
+	return 0, nil
+}
+
 func (k *KubernetesClient) GetAllServicesList(namespace string) (runtime.Object, error) {
 	return k.clientSet.CoreV1().Services(namespace).List(k.Context, metav1.ListOptions{})
 }


### PR DESCRIPTION
We should generate previous logs if pods restarted. That would help to investigate issues with more information.

e.g.
If we have longhorn manager logs like the following:
```
harvester-node-0:/var/log/pods/longhorn-system_longhorn-manager-llpkl_ee9cee76-22fd-4988-a47d-7f408b7ab444/longhorn-manager # ls -al
-rw-r----- 1 root root   736805 Dec 13 20:52 0.log
-rw-r----- 1 root root 10485891 Dec 13 08:44 0.log.20221213-084430
-rw-r----- 1 root root  6376246 Dec 23 02:49 1.log
-rw-r----- 1 root root 10485786 Dec 19 19:38 1.log.20221219-193902
```
we only generate the longhorn-manager.log for the latest log (means 12/19 - 12/23).

Sometimes we may need the previous logs for debugging. With this PR we may get longhorn-manager.log.1 for the previous log (means 12/13 - 12/19).

Thanks!