### PR TITLE
feat: add new parameter `SUPPORT_BUNDLE_COLLECTOR` to specify collector script to execute

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -52,6 +52,7 @@ func init() {
 	managerCmd.PersistentFlags().StringVar(&sbm.ImagePullPolicy, "image-pull-policy", os.Getenv("SUPPORT_BUNDLE_IMAGE_PULL_POLICY"), "Pull policy of the support bundle image")
 	managerCmd.PersistentFlags().StringVar(&sbm.NodeSelector, "node-selector", os.Getenv("SUPPORT_BUNDLE_NODE_SELECTOR"), "NodeSelector of agent DaemonSet. e.g., key1=value1,key2=value2")
 	managerCmd.PersistentFlags().StringVar(&sbm.RegistrySecret, "registry-secret", os.Getenv("SUPPORT_BUNDLE_REGISTRY_SECRET"), "The registry secret for image pull")
+	managerCmd.PersistentFlags().StringVar(&sbm.SpecifyCollector, "specify-collector", os.Getenv("SUPPORT_BUNDLE_COLLECTOR"), "Execute specify collector script. e.g., longhorn")
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.ExcludeResourceList, "exclude-resources", getEnvStringSlice("SUPPORT_BUNDLE_EXCLUDE_RESOURCES"), "List of resources to exclude. e.g., settings.harvesterhci.io,secrets")
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.BundleCollectors, "extra-collectors", getEnvStringSlice("SUPPORT_BUNDLE_EXTRA_COLLECTORS"), "Get extra resource for the specific components e.g., harvester")
 }

--- a/hack/collector-default
+++ b/hack/collector-default
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+HOST_PATH=$1
+BUNDLE_DIR=$2
+
+# RKE2: Logs for the kubelet are save in rke2 agent log folder
+RKE2_KUBELET_LOG_PATH=${HOST_PATH}/var/lib/rancher/rke2/agent/logs/kubelet.log
+
+function collect_sysinfo(){
+    cd ${BUNDLE_DIR}
+    mkdir -p hostinfos
+    cd hostinfos
+    
+    echo "hostname : " `cat ${HOST_PATH}/etc/hostname` > hostinfo
+    echo "os-release : " `cat ${HOST_PATH}/etc/os-release` >> hostinfo
+    echo "system-info : " `uname -a` >> hostinfo
+
+    # Boot Configuration
+    cat ${HOST_PATH}/boot/config-$(uname -r) > kernel_config
+}
+
+function collect_dmesg(){
+    dmesg -HTx &> dmesg.log
+}
+
+function collect_syslog(){
+    tail -c 10m ${HOST_PATH}/var/log/syslog > syslog.log
+}
+
+function collect_kubelet_log(){
+    # On Linux nodes that use systemd, the kubelet and container runtime write to journald by default. 
+    # ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/#log-location-node
+    chroot ${HOST_PATH} /usr/bin/journalctl -r -u kubelet > kubelet.log
+    
+    if [ -f ${RKE2_KUBELET_LOG_PATH} ]; then
+        cp ${RKE2_KUBELET_LOG_PATH} .
+    fi
+}
+
+function collect_logs(){
+    cd ${BUNDLE_DIR}
+    mkdir -p logs
+    cd logs
+
+    collect_dmesg
+    collect_syslog
+    collect_kubelet_log
+}
+
+collect_sysinfo
+collect_logs

--- a/hack/collector-longhorn
+++ b/hack/collector-longhorn
@@ -10,10 +10,10 @@ function collect_sysinfo(){
     cd ${BUNDLE_DIR}
     mkdir -p hostinfos
     cd hostinfos
-    
-    echo "hostname : " `cat ${HOST_PATH}/etc/hostname` > hostinfo
-    echo "os-release : " `cat ${HOST_PATH}/etc/os-release` >> hostinfo
-    echo "system-info : " `uname -a` >> hostinfo
+
+    echo -e "hostname : \n `cat ${HOST_PATH}/etc/hostname | sed "s/^/\t/"`" > hostinfo
+    echo -e "os-release : \n `cat ${HOST_PATH}/etc/os-release | sed "s/^/\t/"`" >> hostinfo
+    echo -e "system-info : \n `uname -a | sed "s/^/\t/"`" >> hostinfo
 
     # Boot Configuration
     cat ${HOST_PATH}/boot/config-$(uname -r) > kernel_config
@@ -24,7 +24,7 @@ function collect_dmesg(){
 }
 
 function collect_syslog(){
-    tail -c 10m ${HOST_PATH}/var/log/syslog > syslog.log
+    cp ${HOST_PATH}/var/log/syslog* .
 }
 
 function collect_kubelet_log(){

--- a/hack/support-bundle-collector.sh
+++ b/hack/support-bundle-collector.sh
@@ -26,8 +26,8 @@ if [ -x "$(which $OS_COLLECTOR)" ]; then
     $OS_COLLECTOR $HOST_PATH $BUNDLE_DIR
 else
     echo "No OS collector found"
+    collector-default $HOST_PATH $BUNDLE_DIR
 fi
-
 
 cd ${OUTPUT_DIR}
 zip -r node_bundle.zip $(basename ${BUNDLE_DIR})

--- a/hack/support-bundle-collector.sh
+++ b/hack/support-bundle-collector.sh
@@ -21,12 +21,17 @@ if [ -z "$OS_ID" ]; then
     exit 1
 fi
 
-OS_COLLECTOR="collector-$OS_ID"
+if [ -n "$SUPPORT_BUNDLE_COLLECTOR" ]; then
+    OS_COLLECTOR="collector-$SUPPORT_BUNDLE_COLLECTOR"
+else
+    OS_COLLECTOR="collector-$OS_ID"
+fi
+echo "OS_COLLECTOR="${OS_COLLECTOR}
+
 if [ -x "$(which $OS_COLLECTOR)" ]; then
     $OS_COLLECTOR $HOST_PATH $BUNDLE_DIR
 else
     echo "No OS collector found"
-    collector-default $HOST_PATH $BUNDLE_DIR
 fi
 
 cd ${OUTPUT_DIR}

--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/support-bundle-kit/pkg/types"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/support-bundle-kit/pkg/types"
 )
 
 type AgentDaemonSet struct {
@@ -99,6 +100,10 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) error {
 								{
 									Name:  "SUPPORT_BUNDLE_MANAGER_URL",
 									Value: managerURL,
+								},
+								{
+									Name:  "SUPPORT_BUNDLE_COLLECTOR",
+									Value: a.sbm.SpecifyCollector,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -41,6 +41,7 @@ type SupportBundleManager struct {
 	ExcludeResources    []schema.GroupResource
 	ExcludeResourceList []string
 	BundleCollectors    []string
+	SpecifyCollector    string
 
 	context context.Context
 


### PR DESCRIPTION
[Longhorn 5073](https://github.com/longhorn/longhorn/issues/5073)

Signed-off-by: Ray Chang <ray.chang@suse.com>

Add `collector-default` to collect cluster host information and log includes syslog, dmesg, kernel log and kubelet log

![image](https://user-images.githubusercontent.com/17548901/210938861-5c55b2c3-2021-4f41-b46d-9ea3af2ad3b4.png)
