### PR TITLE
fix: add os distro fault tolerant in support bundle collector

### DIFF
--- a/hack/support-bundle-collector.sh
+++ b/hack/support-bundle-collector.sh
@@ -15,15 +15,15 @@ BUNDLE_DIR="${OUTPUT_DIR}/${NODE_NAME}"
 
 mkdir -p ${BUNDLE_DIR}
 
-OS_ID=$(bash -c "source $HOST_PATH/etc/os-release && echo \$ID")
-if [ -z "$OS_ID" ]; then
-    echo "Unable to determine OS ID"
-    exit 1
-fi
-
 if [ -n "$SUPPORT_BUNDLE_COLLECTOR" ]; then
     OS_COLLECTOR="collector-$SUPPORT_BUNDLE_COLLECTOR"
 else
+    OS_ID=$(bash -c "source ${HOST_PATH}/etc/os-release && echo \$ID")
+    if [ -z "$OS_ID" ]; then
+        echo "Unable to determine OS ID"
+        exit 1
+    fi
+    
     OS_COLLECTOR="collector-$OS_ID"
 fi
 echo "OS_COLLECTOR="${OS_COLLECTOR}


### PR DESCRIPTION
[Longhorn 5670](https://github.com/longhorn/longhorn/issues/5670)

Signed-off-by: Ray Chang <ray.chang@suse.com>

Add to check if the os distro. file exits, and continue to collect other information even exception happened. 

Below is the test result:
 - rename the `/etc/os-release` to make the file not exits
   <img width="496" alt="截圖 2023-03-28 下午4 45 26" src="https://user-images.githubusercontent.com/17548901/228181109-a0cab4f0-4943-425d-b020-6481cd20cc2f.png">
 - Success to use `collect-longhorn.sh` to collect infos and logs
   <img width="1306" alt="截圖 2023-03-28 下午4 47 27" src="https://user-images.githubusercontent.com/17548901/228181692-a1d5e209-d1b5-4e6d-b005-e84d1a29c14e.png">
 - if using the old version of support-bundle-kit, the pod will stuck in "No such file or directory" exception
   <img width="1028" alt="截圖 2023-03-28 下午4 55 12" src="https://user-images.githubusercontent.com/17548901/228183875-df90b23e-16b3-4b1c-927b-b2bd45d87649.png">
