### PR TITLE
fix(agent): completed without expected nodes

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -392,6 +392,9 @@ func (m *SupportBundleManager) getAgentNodesIn(podList *v1.PodList) ([]*v1.Node,
 }
 
 func (m *SupportBundleManager) refreshNodes(agentDaemonSet *appsv1.DaemonSet) error {
+	m.nodesLock.Lock()
+	defer m.nodesLock.Unlock()
+
 	podList, err := m.getAgentPodsCreatedBy(agentDaemonSet)
 	if err != nil {
 		return err


### PR DESCRIPTION
Since we've moved the `m.refreshNodes` post DaemonSet creation. Hence should lock the expected nodes to ensure this gets refreshed first before proceeding to compare for completion.

Ref:
- https://github.com/rancher/support-bundle-kit/issues/57
- https://github.com/longhorn/longhorn/issues/5614