### PR TITLE
fix: collector-longhorn

### DIFF
--- a/hack/collector-longhorn
+++ b/hack/collector-longhorn
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -ux
 
 HOST_PATH=$1
 BUNDLE_DIR=$2
@@ -28,10 +28,10 @@ function collect_syslog(){
 }
 
 function collect_kubelet_log(){
-    # On Linux nodes that use systemd, the kubelet and container runtime write to journald by default. 
+    # On Linux nodes that use systemd, the kubelet and container runtime write to journald by default.
     # ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/#log-location-node
     chroot ${HOST_PATH} /usr/bin/journalctl -r -u kubelet > kubelet.log
-    
+
     if [ -f ${RKE2_KUBELET_LOG_PATH} ]; then
         cp ${RKE2_KUBELET_LOG_PATH} .
     fi

--- a/hack/collector-longhorn
+++ b/hack/collector-longhorn
@@ -24,7 +24,10 @@ function collect_dmesg(){
 }
 
 function collect_syslog(){
+    # Different Linux distributions use different syslog daemons, which store log messages in different locations.
+    # The common locations are /var/log/syslog and /var/log/messages.
     cp ${HOST_PATH}/var/log/syslog* .
+    cp ${HOST_PATH}/var/log/messages* .
 }
 
 function collect_kubelet_log(){


### PR DESCRIPTION
~Fix 1: https://github.com/longhorn/longhorn/issues/6338
Including archived syslog files is significantly inflating the size of the support bundle and is meaningless. We will only gather the most recent log entries that are not too far ago from the incident.~

Fix 2: https://github.com/longhorn/longhorn/issues/6544
Currently, the support bundle only collects [syslog from /var/log/syslog](https://github.com/rancher/support-bundle-kit/blob/v0.0.26/hack/collector-longhorn#L27). Without collecting from /var/log/messages we are overlooking the syslog collection for some Longhorn-supported operating systems, such as SUSE.