### PR TITLE
feature(agent): add containerd log in harvester

### DIFF
--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -98,4 +98,5 @@ for unit in ${units[@]}; do
 done
 
 cp ${HOST_PATH}/var/lib/rancher/rke2/agent/logs/kubelet.log .
+cp ${HOST_PATH}/var/lib/rancher/rke2/agent/containerd/containerd.log .
 cp ${HOST_PATH}/var/log/console.log .

--- a/pkg/manager/agent.go
+++ b/pkg/manager/agent.go
@@ -34,6 +34,10 @@ func (a *AgentDaemonSet) Create(image string, managerURL string) (*appsv1.Daemon
 		return nil, err
 	}
 
+	if len(pods.Items) == 0 {
+		return nil, errors.New("no support bundle manager pod found")
+	}
+
 	if len(pods.Items) != 1 {
 		return nil, errors.New("more than one support bundle manager pods are found")
 	}


### PR DESCRIPTION
# Summary

Based on this suggestion from issue https://github.com/harvester/harvester/issues/4427, I modify `collector-harvester` to collect `containerd.log`.

# How I found the path to fix and verify

## Understand how it works

First of all, I read the README and wiki to understand what/how this repo works, and took a look at folder structure to notice there are docs, scripts, hack and pkg might be important.

Then I tried to deploy to obtain more information in local k3d. I encountered a service account problem which doesn't exist in my cluster. It's normal behavior because I didn't install a harvester in my cluster. So, I created a service account for support-bundle-kit and granted it access to the kubernetes API.

After deploying successfully, I could see the log of bundling log files, but I found an error message `more than one support bundle manager pods are found`. It stopped the manager creating a daemonset to collect node's log. Regarding the `if-else` condition of code, I found the example manifest doesn't match the label which program tries to select. There is a difference between code and manifest.

In manifest, you could see the label is `rancher.io/support-bundle=sample` in https://github.com/rancher/support-bundle-kit/blob/master/deploy/manifests/support-bundle-manager.yaml#L6-L7. But, it's `rancher/supportbundle={value_from_env}` in https://github.com/rancher/support-bundle-kit/blob/master/pkg/types/types.go#L19, so it's a different key. 

After I fixed the example yaml by adding `SUPPORT_BUNDLE_COLLECTOR` and modifying label, I could see the agent starting to collect the node log.

## Follow the issue description

According to the issue and `support-bundle-collector.sh`, I found `collector-harvester` is the main role to collect logs in rke2 cluster. So, I add `cp ${HOST_PATH}/var/lib/rancher/rke2/agent/containerd/containerd.log .` in `collector-harvester`. Then, I need to verify it works as I expect.

## How to verify

I tried dev-mode docs to install harvester in local k3d, but it didn't work for installation, then I realized I needed rke2 instead of k3os. Luckily, I have a Windows computer that can install VirtualBox. After installing the harvester in the VirtualBox, I did see the container log path. By the way, I also tried to install Harvester into VirtualBox in M2 Mac, but it didn't work as well. Next, I need to figure out how to deploy support-bundle-kit in VirtualBox.

I modified the code and ran `script/default` to build an executable file and push the image to [docker hub](https://hub.docker.com/layers/jk82421/support-bundle-kit/v1.0.0-amd64/images/sha256-e6e2bf0e0df92be39faf2db828003c8ed22bcfca47d022905a7c6eccaddaa6ef?context=repo). However, I ran into the OS problem because I used Mac to build. I fixed it by https://go.dev/doc/install/source#environment and used `--platform=linux/amd64` to build the image.

Following are before and after comparison screenshots after agent posted node logs to manager.

![before-feature-manager](https://github.com/rancher/support-bundle-kit/assets/6960289/a4f30507-b9d9-45e9-9da3-40e8218606bd)

![after-feature-manager](https://github.com/rancher/support-bundle-kit/assets/6960289/c9d5e6a5-dded-424d-9071-548e1db2cf10)

# Other thoughts

Due to the mismatched label, the code doesn’t select the manager pod correctly. I think we could add one more condition for developers to obtain more information when the selector gets zero pods.
https://github.com/rancher/support-bundle-kit/pull/79/files#diff-df9968bf3ccabbe861d3e72f47323abf9cb421f8e238b1a4506ef8a58c1646d5R37-R40