### PR TITLE
Fix SBK to eliminate empty YAML file

### DIFF
--- a/pkg/manager/client/discovery.go
+++ b/pkg/manager/client/discovery.go
@@ -102,7 +102,12 @@ func (dc *DiscoveryClient) SpecificResourcesForNamespace(toObj ParseResult, modu
 				if err != nil {
 					return nil, err
 				}
-				objs[gv.String()+"/"+resource.Name] = obj
+				// skip empty object, which will cause useless zero item yaml file
+				if obj != nil {
+					objs[gv.String()+"/"+resource.Name] = obj
+				} else {
+					logrus.Debugf("No %s/%s resource %s in namespace %s, skip", gv.String(), resource.Kind, resource.Name, namespace)
+				}
 			}
 
 		}
@@ -164,13 +169,17 @@ func (dc *DiscoveryClient) ResourcesForNamespace(toObj ParseResult, namespace st
 				if err != nil {
 					return nil, err
 				}
-				objs[gv.String()+"/"+resource.Name] = obj
+				// skip empty object, which will cause useless zero item yaml file
+				if obj != nil {
+					objs[gv.String()+"/"+resource.Name] = obj
+				} else {
+					logrus.Debugf("No %s/%s resource %s in namespace %s, skip", gv.String(), resource.Kind, resource.Name, namespace)
+				}
 			}
 		}
 	}
 
 	return objs, nil
-
 }
 
 // Get the cluster level resources
@@ -222,7 +231,10 @@ func (dc *DiscoveryClient) ResourcesForCluster(toObj ParseResult, exclude Exclud
 				if err != nil {
 					return nil, err
 				}
-				objs[gv.String()+"/"+resource.Name] = obj
+				// skip empty object
+				if obj != nil {
+					objs[gv.String()+"/"+resource.Name] = obj
+				}
 			}
 		}
 	}

--- a/pkg/manager/collectors/common.go
+++ b/pkg/manager/collectors/common.go
@@ -82,6 +82,11 @@ func (c common) toObjCommon(b []byte, groupVersion, kind string) (*gabs.Containe
 		return nil, err
 	}
 
+	// When there is no instance of the given GVK, return nil
+	if len(jsonParsed.S("items").Children()) == 0 {
+		return nil, nil
+	}
+
 	for _, child := range jsonParsed.S("items").Children() {
 		if _, err = child.SetP(groupVersion, "apiVersion"); err != nil {
 			logrus.Error("Unable to set apiVersion field.")

--- a/pkg/manager/collectors/harvester.go
+++ b/pkg/manager/collectors/harvester.go
@@ -121,7 +121,7 @@ func (module harvesterModule) toClusterObj(b []byte, groupVersion, kind string, 
 	switch kind {
 	case "Setting":
 		currentItems, _ := jsonParsed.S("items").Data().([]interface{})
-		logrus.Debugf("Whole items: %v", currentItems)
+		logrus.Debugf("Whole items in cluster: %v", currentItems)
 		var newItems []interface{}
 		for _, item := range currentItems {
 			gItem := gabs.Wrap(item)


### PR DESCRIPTION
issue:
https://github.com/rancher/support-bundle-kit/issues/78

Generating YAML files of almost all resources in all namespaces, most of them are nearly empty, increase the difficulty to look/search target object in the SB file.

local test result:
https://github.com/rancher/support-bundle-kit/issues/78#issuecomment-1714013380

After the fix, the `yamls` fold will strip such kind of empty file:

```
cat ./yamls/namespaced/harvester-system/rke.cattle.io/v1/rkecontrolplanes.yaml
apiVersion: v1
items: []
kind: List
metadata:
  continue: "null"
  resourceVersion: "39418564"
```

each yaml file will have at least 1 list item.