### PR TITLE
fix(manager): fetch metadata from ENV

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -56,4 +56,6 @@ func init() {
 	managerCmd.PersistentFlags().StringVar(&sbm.SpecifyCollector, "specify-collector", os.Getenv("SUPPORT_BUNDLE_COLLECTOR"), "Execute specify collector script. e.g., longhorn")
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.ExcludeResourceList, "exclude-resources", getEnvStringSlice("SUPPORT_BUNDLE_EXCLUDE_RESOURCES"), "List of resources to exclude. e.g., settings.harvesterhci.io,secrets")
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.BundleCollectors, "extra-collectors", getEnvStringSlice("SUPPORT_BUNDLE_EXTRA_COLLECTORS"), "Get extra resource for the specific components e.g., harvester")
+	managerCmd.PersistentFlags().StringVar(&sbm.Description, "description", os.Getenv("SUPPORT_BUNDLE_DESCRIPTION"), "The support bundle description")
+	managerCmd.PersistentFlags().StringVar(&sbm.IssueURL, "issue-url", os.Getenv("SUPPORT_BUNDLE_ISSUE_URL"), "The support bundle issue url")
 }

--- a/pkg/manager/cluster.go
+++ b/pkg/manager/cluster.go
@@ -43,19 +43,14 @@ func (c *Cluster) GenerateClusterBundle(bundleDir string) (string, error) {
 		return "", errors.Wrap(err, "cannot get kubernetes version")
 	}
 
-	sb, err := c.sbm.state.GetSupportBundle(c.sbm.PodNamespace, c.sbm.BundleName)
-	if err != nil {
-		return "", errors.Wrap(err, "cannot get support bundle")
-	}
-
 	bundleMeta := &BundleMeta{
-		BundleName:           sb.Name,
+		BundleName:           c.sbm.BundleName,
 		BundleVersion:        BundleVersion,
 		KubernetesVersion:    kubeVersion.GitVersion,
 		ProjectNamespaceUUID: string(namespace.UID),
 		BundleCreatedAt:      utils.Now(),
-		IssueURL:             sb.Spec.IssueURL,
-		IssueDescription:     sb.Spec.Description,
+		IssueURL:             c.sbm.IssueURL,
+		IssueDescription:     c.sbm.Description,
 	}
 
 	bundleName := fmt.Sprintf("supportbundle_%s_%s.zip",

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -41,6 +41,8 @@ type SupportBundleManager struct {
 	NodeSelector    string
 	TaintToleration string
 	RegistrySecret  string
+	IssueURL        string
+	Description     string
 
 	ExcludeResources    []schema.GroupResource
 	ExcludeResourceList []string

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -23,6 +23,5 @@ type BundleMeta struct {
 }
 
 type StateStoreInterface interface {
-	GetSupportBundle(namespace, supportbundle string) (*types.SupportBundle, error)
 	GetState(namespace, supportbundle string) (types.SupportBundleState, error)
 }


### PR DESCRIPTION
## Problem Description
Because we fetch custom resource from local_state which we create by ourself, so we should fetch custom resource from kubernetes API. However, there is another manager uses support bundle kit in different api group.

## Solution
We could fetch data from env which the manager will give when manager create support bundle manager. It would be easier than fetching k8s api by telling who owns this support bundle kit manager.


## Test plan
This will follow https://github.com/harvester/harvester/pull/4662 test plan to test.

## Related Issue
https://github.com/harvester/harvester/issues/4630