### PR TITLE
fix: support bundle kit build failed

### DIFF
--- a/pkg/simulator/etcd/etcd_test.go
+++ b/pkg/simulator/etcd/etcd_test.go
@@ -19,7 +19,7 @@ func TestRunEmbeddedEtcdWithoutCerts(t *testing.T) {
 	}
 
 	defer os.RemoveAll(dir)
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	// run an insecure etcd server
@@ -71,7 +71,7 @@ func TestRunEmbeddedEtcdWithCerts(t *testing.T) {
 	}
 
 	defer os.RemoveAll(dir)
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	certificates, err := certs.GenerateCerts([]string{"localhost", "127.0.0.1"}, dir)

--- a/scripts/validate
+++ b/scripts/validate
@@ -15,4 +15,4 @@ if [[ -z "$(command -v golangci-lint)" ]]; then
 fi
 
 echo "Running: golangci-lint run"
-golangci-lint run --timeout 10m
+golangci-lint run --timeout 30m


### PR DESCRIPTION
Try to fix #82. My assumption is that assigned could run out of resource or is not top priority, so increase timeout here to fix it temporarily. But, if it happens again, still need more investigation.

First part timeout is golangci-lint might take too long. Second part is etcd, in my opinion, it might cause unexpected closing with only 120 second timeout in s390x to lead to `address already in use`