### PR TITLE
feat: add ctr image list

### DIFF
--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -42,6 +42,14 @@ collect_etc() {
     rm -f $to_dir/rancher/rke2/rke2.yaml
 }
 
+collect_images_info() {
+    local rke2_bin=$(readlink ${HOST_PATH}/var/lib/rancher/rke2/bin)
+
+    ${HOST_PATH}${rke2_bin}/ctr \
+      --address ${HOST_PATH}/run/k3s/containerd/containerd.sock \
+      -n k8s.io images ls > containerd-images.log
+}
+
 remove_oem_secrets() {
     local oem_dir=$1
     local header=""
@@ -100,3 +108,5 @@ done
 cp ${HOST_PATH}/var/lib/rancher/rke2/agent/logs/kubelet.log .
 cp ${HOST_PATH}/var/lib/rancher/rke2/agent/containerd/containerd.log .
 cp ${HOST_PATH}/var/log/console.log .
+
+collect_images_info

--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -43,6 +43,8 @@ collect_etc() {
 }
 
 collect_images_info() {
+    # In this case, we can't use /host/var/lib/rancher/rke2/bin directly because of host volume mount and symbolic link problem.
+    # So, we need to use real bin path to execute command with `readlink` command.
     local rke2_bin=$(readlink ${HOST_PATH}/var/lib/rancher/rke2/bin)
 
     ${HOST_PATH}${rke2_bin}/ctr \


### PR DESCRIPTION
### Related Issue

https://github.com/harvester/harvester/issues/3838

### Problem

The image GC will cause some potential problems which https://github.com/harvester/harvester/issues/3838 describes, so it would be better for debugging if we could provide a image list the users used. So, we could use the list to double check whether environment missed essential images or not.

### Solution

Run the host command to fetch image list. But, in this case, we can't use `/host/var/lib/rancher/rke2/bin` directly because of host volume mount and symbolic link problem. It causes the not found problem in this path `/host/var/lib/rancher/rke2/bin`. So, we need to use real bin path to execute command with `readlink` command.

Unless we directly mount host's `/var/lib/rancher/rke2/bin` when creating daemonset, but I think it would be better to control this in our shell script.

### Test Plan

Use new image to generate support bundle, then you could see containerd-image.log in the **node logs folder (nodes/)**. 

![image](https://github.com/rancher/support-bundle-kit/assets/6960289/d1bd5111-7d08-40ee-b25e-133cc5bcc336)
