### PR TITLE
fix: manifest typo

### DIFF
--- a/deploy/manifests/support-bundle-manager.yaml
+++ b/deploy/manifests/support-bundle-manager.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: support-bundle-manager
-    rancher.io/support-bundle: sample
+    rancher/supportbundle: sample
   name: supportbundle-manager-sample
   namespace: harvester-system
 spec:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: support-bundle-manager
-        rancher.io/support-bundle: sample
+        rancher/supportbundle: sample
     spec:
       containers:
       - args:


### PR DESCRIPTION
## Description

According to https://github.com/rancher/support-bundle-kit/blob/master/pkg/manager/agent.go#L30, it uses these labels https://github.com/rancher/support-bundle-kit/blob/master/pkg/types/types.go#L18-L23 to check manager exists or not. So, we need to correct it.

## Test plan

Run `kubectl apply -f deploy/manifests/support-bundle-manager.yaml`. It would succeed to fetch node log.