### PR TITLE
fix: support bundle daemonset condition

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -368,7 +368,7 @@ func (m *SupportBundleManager) getAgentPodsCreatedBy(daemonSet *appsv1.DaemonSet
 		}
 
 		// Check if all desired Pods have been scheduled
-		if len(filteredPods) != 0 && len(pods.Items) == int(daemonSet.Status.DesiredNumberScheduled) {
+		if len(filteredPods) != 0 && len(filteredPods) == int(daemonSet.Status.DesiredNumberScheduled) {
 			return &v1.PodList{Items: filteredPods}, nil
 		}
 


### PR DESCRIPTION
## Description

When you create multiple support bundle at the same time, they're stuck for waiting daemonset condition until timeout.

In general, there is no such case which creates multiple support bundle at the same time, but there is still an issue for that case, so I think we need to fix it.

## How to reproduce

<details>
<summary>Click to toggle contents of testing yaml</summary>

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: support-bundle-manager
    rancher/supportbundle: sample-01
  name: supportbundle-manager-sample-01
  namespace: harvester-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: support-bundle-manager
  template:
    metadata:
      labels:
        app: support-bundle-manager
        rancher/supportbundle: sample-01
    spec:
      containers:
      - args:
        - /usr/bin/support-bundle-kit
        - manager
        env:
        - name: SUPPORT_BUNDLE_TARGET_NAMESPACES
          value: harvester-system,longhorn-system
        - name: SUPPORT_BUNDLE_NAME
          value: sample-01
        - name: SUPPORT_BUNDLE_DEBUG
          value: "true"
        - name: SUPPORT_BUNDLE_MANAGER_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: SUPPORT_BUNDLE_IMAGE
          value: rancher/support-bundle-kit:master-head
        - name: SUPPORT_BUNDLE_IMAGE_PULL_POLICY
          value: Always
        image: rancher/support-bundle-kit:master-head
        imagePullPolicy: Always
        name: manager
        ports:
        - containerPort: 8080
          protocol: TCP
      serviceAccountName: harvester
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: support-bundle-manager
    rancher/supportbundle: sample-02
  name: supportbundle-manager-sample-02
  namespace: harvester-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: support-bundle-manager
  template:
    metadata:
      labels:
        app: support-bundle-manager
        rancher/supportbundle: sample-02
    spec:
      containers:
      - args:
        - /usr/bin/support-bundle-kit
        - manager
        env:
        - name: SUPPORT_BUNDLE_TARGET_NAMESPACES
          value: harvester-system,longhorn-system
        - name: SUPPORT_BUNDLE_NAME
          value: sample-02
        - name: SUPPORT_BUNDLE_DEBUG
          value: "true"
        - name: SUPPORT_BUNDLE_MANAGER_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: SUPPORT_BUNDLE_IMAGE
          value: rancher/support-bundle-kit:master-head
        - name: SUPPORT_BUNDLE_IMAGE_PULL_POLICY
          value: Always
        image: rancher/support-bundle-kit:master-head
        imagePullPolicy: Always
        name: manager
        ports:
        - containerPort: 8080
          protocol: TCP
      serviceAccountName: harvester
```
</details>

Use above yaml to create two support bundle manager, and these two support bundle manager will stuck for waiting daemonset condition checking like below until timeout. 

![image](https://github.com/rancher/support-bundle-kit/assets/6960289/8993317d-31a6-48e6-8414-570a6374d25b)

Although daemonset was created in the end, and it worked. But, we don't need to wait for timeout.

![image](https://github.com/rancher/support-bundle-kit/assets/6960289/7eba5e99-8017-4715-87a9-784ebf7fae13)

![image](https://github.com/rancher/support-bundle-kit/assets/6960289/96eac357-e779-4b1b-9dc1-e7f82a1c4725)

## Test Plan

<details>
<summary>Click to toggle contents of testing yaml</summary>

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: support-bundle-manager
    rancher/supportbundle: sample-01
  name: supportbundle-manager-sample-01
  namespace: harvester-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: support-bundle-manager
  template:
    metadata:
      labels:
        app: support-bundle-manager
        rancher/supportbundle: sample-01
    spec:
      containers:
      - args:
        - /usr/bin/support-bundle-kit
        - manager
        env:
        - name: SUPPORT_BUNDLE_TARGET_NAMESPACES
          value: harvester-system,longhorn-system
        - name: SUPPORT_BUNDLE_NAME
          value: sample-01
        - name: SUPPORT_BUNDLE_DEBUG
          value: "true"
        - name: SUPPORT_BUNDLE_MANAGER_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: SUPPORT_BUNDLE_IMAGE
          value: jk82421/support-bundle-kit:v0.0.34.6
        - name: SUPPORT_BUNDLE_IMAGE_PULL_POLICY
          value: Always
        image: jk82421/support-bundle-kit:v0.0.34.6
        imagePullPolicy: Always
        name: manager
        ports:
        - containerPort: 8080
          protocol: TCP
      serviceAccountName: harvester
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: support-bundle-manager
    rancher/supportbundle: sample-02
  name: supportbundle-manager-sample-02
  namespace: harvester-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: support-bundle-manager
  template:
    metadata:
      labels:
        app: support-bundle-manager
        rancher/supportbundle: sample-02
    spec:
      containers:
      - args:
        - /usr/bin/support-bundle-kit
        - manager
        env:
        - name: SUPPORT_BUNDLE_TARGET_NAMESPACES
          value: harvester-system,longhorn-system
        - name: SUPPORT_BUNDLE_NAME
          value: sample-02
        - name: SUPPORT_BUNDLE_DEBUG
          value: "true"
        - name: SUPPORT_BUNDLE_MANAGER_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: SUPPORT_BUNDLE_IMAGE
          value: jk82421/support-bundle-kit:v0.0.34.6
        - name: SUPPORT_BUNDLE_IMAGE_PULL_POLICY
          value: Always
        image: jk82421/support-bundle-kit:v0.0.34.6
        imagePullPolicy: Always
        name: manager
        ports:
        - containerPort: 8080
          protocol: TCP
      serviceAccountName: harvester
```
</details>

> Testing image: jk82421/support-bundle-kit:v0.0.34.6

Use above yaml to create two support bundle manager, and these two support bundle manager won't encounter timeout issue.

![image](https://github.com/rancher/support-bundle-kit/assets/6960289/acb1b401-630f-4a84-a07f-6ffb07326c6f)


## Related Issue

https://github.com/harvester/harvester/issues/4922