### PR TITLE
harvester-collector: reduce supportconfig features

### DIFF
--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -90,7 +90,8 @@ mkdir -p logs
 cd logs
 
 # Generate supportconfig from node
-chroot $HOST_PATH /sbin/supportconfig -c -Q -B supportconfig_$SUPPORT_BUNDLE_NODE_NAME
+chroot $HOST_PATH /sbin/supportconfig -c -m -B supportconfig_$SUPPORT_BUNDLE_NODE_NAME \
+    -i BOOT,DAEMONS,ETC,ISCSI,MEM,MOD,NTP,SMART,DISK,pharvester_plugin_rke2,pharvester_plugin_console
 mv $HOST_PATH/var/log/scc_supportconfig_$SUPPORT_BUNDLE_NODE_NAME.txz .
 
 chroot $HOST_PATH /usr/bin/journalctl -k > kernel.log


### PR DESCRIPTION
By default, supportconfig collects too much system info and this might exceed the support bundle manager timeout. Reduce the features to minimum features and some selected ones.

**Related issue**
https://github.com/harvester/harvester/issues/5323

**Test plan**
- Build the code and push the container image to a repo. You can test with `bk201z/support-bundle-kit:wip-5323`
- Edit setting `support-bundle-image` with `kubectl edit settings.harvesterhci.io/support-bundle-image` and set the value to the published image, for example:
  ```
  value: '{"repository":"bk201z/support-bundle-kit","tag":"wip-5323","imagePullPolicy":"Always"}'
  ```
- Collect a support bundle and it should work. Comparing to the default image, you should notice the time to generate a support bundle is reduced.
- Check the support bundle file for the supportconfig tarball, should see a 
 supportconfig tarball `nodes/<node_name>/logs/scc_supportconfig_harvester_xxx.txz`, and its content:

    <img width="541" alt="截圖 2024-03-08 下午4 46 56" src="https://github.com/rancher/support-bundle-kit/assets/1691518/e385186a-6831-4315-8cfb-23e35a707e52">
