### PR TITLE
Log underlying error when YAML generation fails

### DIFF
--- a/pkg/manager/client/discovery.go
+++ b/pkg/manager/client/discovery.go
@@ -100,7 +100,10 @@ func (dc *DiscoveryClient) SpecificResourcesForNamespace(toObj ParseResult, modu
 			if err == nil {
 				obj, err := toObj(b, gv.String(), resource.Kind, resource.Name)
 				if err != nil {
-					return nil, err
+					// This is unexpected. Log, but continue to try other resources.
+					logrus.Errorf("Failed to parse objects received from %s: %v", url, result.Error())
+					fmt.Fprintf(errLog, "Failed to parse objects received from %s: %v\n", url, result.Error())
+					continue
 				}
 				// skip empty object, which will cause useless zero item yaml file
 				if obj != nil {
@@ -167,7 +170,10 @@ func (dc *DiscoveryClient) ResourcesForNamespace(toObj ParseResult, namespace st
 			if err == nil {
 				obj, err := toObj(b, gv.String(), resource.Kind)
 				if err != nil {
-					return nil, err
+					// This is unexpected. Log, but continue to try other resources.
+					logrus.Errorf("Failed to parse objects received from %s: %v", url, result.Error())
+					fmt.Fprintf(errLog, "Failed to parse objects received from %s: %v\n", url, result.Error())
+					continue
 				}
 				// skip empty object, which will cause useless zero item yaml file
 				if obj != nil {
@@ -229,7 +235,10 @@ func (dc *DiscoveryClient) ResourcesForCluster(toObj ParseResult, exclude Exclud
 			if err == nil {
 				obj, err := toObj(b, gv.String(), resource.Kind)
 				if err != nil {
-					return nil, err
+					// This is unexpected. Log, but continue to try other resources.
+					logrus.Errorf("Failed to parse objects received from %s: %v", url, result.Error())
+					fmt.Fprintf(errLog, "Failed to parse objects received from %s: %v\n", url, result.Error())
+					continue
 				}
 				// skip empty object
 				if obj != nil {

--- a/pkg/manager/collectors/cluster.go
+++ b/pkg/manager/collectors/cluster.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -26,7 +27,8 @@ func (module clusterModule) generateYAMLs() {
 	objs, err := module.c.discovery.ResourcesForCluster(module.toObj, module.c.exclude, module.c.errorLog)
 
 	if err != nil {
-		logrus.Errorf("Unable to fetch cluster resources: %v", err)
+		logrus.WithError(err).Error("Unable to fetch cluster resources")
+		fmt.Fprintf(module.c.errorLog, "Unable to fetch cluster resources: %v\n", err)
 		return
 	}
 

--- a/pkg/manager/collectors/default.go
+++ b/pkg/manager/collectors/default.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 
@@ -56,7 +57,8 @@ func (module defaultModule) generateDiscoveredNamespacedYAMLs(namespace string, 
 	objs, err := module.c.discovery.ResourcesForNamespace(module.toObj, namespace, module.c.exclude, errLog)
 
 	if err != nil {
-		logrus.Errorf("Unable to fetch namespaced resources: %v", err)
+		logrus.WithError(err).Error("Unable to fetch namespaced resources")
+		fmt.Fprintf(module.c.errorLog, "Unable to fetch namespaced resources: %v\n", err)
 		return
 	}
 

--- a/pkg/manager/collectors/harvester.go
+++ b/pkg/manager/collectors/harvester.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/Jeffail/gabs/v2"
@@ -33,7 +34,8 @@ func (module harvesterModule) generateYAMLs() {
 		objs, err := module.c.discovery.SpecificResourcesForNamespace(module.toObj, module.name, namespace, resourceLists, module.c.errorLog)
 
 		if err != nil {
-			logrus.Errorf("Unable to fetch namespaced resources: %v", err)
+			logrus.WithError(err).Error("Unable to fetch namespaced resources")
+			fmt.Fprintf(module.c.errorLog, "Unable to fetch namespaced resources: %v\n", err)
 			return
 		}
 
@@ -48,7 +50,8 @@ func (module harvesterModule) generateYAMLs() {
 	objs, err := module.c.discovery.ResourcesForCluster(module.toClusterObj, module.skipClusterObjects, module.c.errorLog)
 
 	if err != nil {
-		logrus.Errorf("Unable to fetch cluster scoped resources: %v", err)
+		logrus.WithError(err).Error("Unable to fetch cluster resources")
+		fmt.Fprintf(module.c.errorLog, "Unable to fetch cluster resources: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
Fixes #99 with best-effort.

I can't actually manage to hit an error like the on from https://github.com/rancher/support-bundle-kit/issues/99#issue-2215521652 in my cluster. I tried mangling the `cluster-admin` ClusterRole to remove access to nonResourceURLs and removing the `system:discovery` ClusterRoleBinding in an attempt to stop support-bundle-manager from using the Kubernetes Discovery API. This DID result in a support bundle without YAML files, but did not trigger the `Unable to fetch cluster resources` message (in either a modified or unmodified support-bundle-kit). This means I cannot actually show the result of this PR in action. However, it should provide us additional debugging information if the YAML collection fails again like this in the future.