### PR TITLE
feat: add node timeout

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -58,4 +59,18 @@ func init() {
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.BundleCollectors, "extra-collectors", getEnvStringSlice("SUPPORT_BUNDLE_EXTRA_COLLECTORS"), "Get extra resource for the specific components e.g., harvester")
 	managerCmd.PersistentFlags().StringVar(&sbm.Description, "description", os.Getenv("SUPPORT_BUNDLE_DESCRIPTION"), "The support bundle description")
 	managerCmd.PersistentFlags().StringVar(&sbm.IssueURL, "issue-url", os.Getenv("SUPPORT_BUNDLE_ISSUE_URL"), "The support bundle issue url")
+	managerCmd.PersistentFlags().DurationVar(&sbm.NodeTimeout, "node-timeout", parseNodeTimeout(os.Getenv("SUPPORT_BUNDLE_NODE_TIMEOUT")), "The support bundle node collection time out")
+}
+
+func parseNodeTimeout(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0
+	}
+
+	return d
 }

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -59,10 +59,11 @@ func init() {
 	managerCmd.PersistentFlags().StringSliceVar(&sbm.BundleCollectors, "extra-collectors", getEnvStringSlice("SUPPORT_BUNDLE_EXTRA_COLLECTORS"), "Get extra resource for the specific components e.g., harvester")
 	managerCmd.PersistentFlags().StringVar(&sbm.Description, "description", os.Getenv("SUPPORT_BUNDLE_DESCRIPTION"), "The support bundle description")
 	managerCmd.PersistentFlags().StringVar(&sbm.IssueURL, "issue-url", os.Getenv("SUPPORT_BUNDLE_ISSUE_URL"), "The support bundle issue url")
-	managerCmd.PersistentFlags().DurationVar(&sbm.NodeTimeout, "node-timeout", parseNodeTimeout(os.Getenv("SUPPORT_BUNDLE_NODE_TIMEOUT")), "The support bundle node collection time out")
+	managerCmd.PersistentFlags().DurationVar(&sbm.NodeTimeout, "node-timeout", parseDurationString(os.Getenv("SUPPORT_BUNDLE_NODE_TIMEOUT")), "The support bundle node collection time out")
 }
 
-func parseNodeTimeout(value string) time.Duration {
+// parseDurationString could parse `1s` and `10m` duration string.
+func parseDurationString(value string) time.Duration {
 	if value == "" {
 		return 0
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -304,7 +304,7 @@ func (m *SupportBundleManager) waitNodesCompleted() {
 	case <-m.ch:
 		logrus.Info("All node bundles are received.")
 	case <-m.timeout():
-		logrus.Info("Some node bundles are received.")
+		logrus.Info("Some nodes are timeout, not all node bundles are received.")
 		m.printTimeoutNodes()
 	}
 }


### PR DESCRIPTION
## Problem

Sometime nodes spend too much time collecting logs, even forever. It makes users can't download support bundle kit.


## Solution

Add collecting node timeout. When collecting node reach timeout, it will skip it instead of stuck. Then users are able download support bundle without waiting. But, in the situation, there is no node's logs in support bundle file.

For example, if A node is finished before timeout, but B node isn't finished. There is only A node's logs in support bundle file. So, we're still able to check something.

## Related Issue

https://github.com/harvester/harvester/issues/1646


## Test

This is test case when collecting node reach out the timeout.
```
level=debug msg="Creating daemonset supportbundle-agent-bundle-1wrog with image jk82421/support-bundle-kit:v0.0.36.4"  
level=debug msg="Waiting for the creation of agent DaemonSet Pods for scheduled node names collection"       
level=debug msg="Expecting bundles from nodes: map[jacklnode:]"      
level=info msg="Some node bundles are received." 
level=warning msg="Collection timed out for node: jacklnode"         
level=info msg="Succeed to run phase node bundle. Progress (60)."
```

It's hard to simulate the node stuck for 30 minutes, so I suggest following steps to test:
1. Create support bundle 
2. Change env of deployment/support-bundle-manager-xxxx, set up like this
```
- name: SUPPORT_BUNDLE_NODE_TIMEOUT
   value: "1s"
```
3. Wait for deployment restarting.
4. After downloading support bundle kit, it shouldn't have node logs there.

## TODO

If we're okay with this default timeout, these following features can be postponed.

- [ ] Node timeout setting/documentation for harvester/harvester
- [ ] Node timeout setting/documentation for longhorn