### PR TITLE
ci: simplify the script/package to speed up local development

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,9 @@
+# syntax=docker/dockerfile:1.7.0
+
 FROM registry.suse.com/bci/bci-base:15.5
 
 ARG TARGETPLATFORM
+
 RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
     echo "Error: Unsupported TARGETPLATFORM: $TARGETPLATFORM" && \
     exit 1; \

--- a/scripts/package
+++ b/scripts/package
@@ -11,19 +11,6 @@ cp bin/* dist/artifacts
 IMAGE=${REPO}/support-bundle-kit:${TAG}
 DOCKERFILE=package/Dockerfile
 
-docker run --privileged --rm tonistiigi/binfmt --install all
-buildx create --platform linux/amd64,linux/arm64 --use
-buildx ls
-
-# In old docker version, it doesn't support multiple values in --platform with --load.
-# So we only load image with current platform.
-# Ref: https://github.com/docker/buildx/issues/59#issuecomment-616050491
-
-# build
-buildx build --platform linux/amd64,linux/arm64 \
-  -f ${DOCKERFILE} -t ${IMAGE} .
-
-# test
 buildx build --load \
   -f ${DOCKERFILE} -t ${IMAGE} .
 


### PR DESCRIPTION
I tested following situations, all work:

- Mac M1 execute ./scripts/build && ./scripts/package
- Linux Laptop (amd64) execute ./scripts/build && ./scripts/package
- Github Action
- Local Github Action
- Image can be used in linux/amd64 and linux/arm64 (Tested Image: jk82421/support-bundle-kit:pull-test-ci-01)

Through this change, it can speed up the local development which run ./scripts/package without waiting multiple platform build, and the image is still usable in linux/amd64 and linux/arm64.

Related Issue: https://github.com/harvester/harvester/issues/5327