### PR TITLE
ci: remove useless build args

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -51,5 +51,3 @@ jobs:
           file: package/Dockerfile
           push: ${{ inputs.push }}
           tags: rancher/support-bundle-kit:${{ inputs.release-tag-name }}
-          build-args: |
-            VERSION=${{ github.ref_name }}-${{ github.sha }}-head


### PR DESCRIPTION
I copied this from Drone config before, but I realized VERSION not used in Dockerfile.

BTW, because we changed it from `ARG ARCH` to `ENV ARCH` in Dockerfile due to using buildx which provides TARGETPLATFORM.