### PR TITLE
fixed timestamps and broken logging

### DIFF
--- a/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -252,7 +252,8 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetName(), oldMeta.GetName(), fldPath.Child("name"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetNamespace(), oldMeta.GetNamespace(), fldPath.Child("namespace"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetUID(), oldMeta.GetUID(), fldPath.Child("uid"))...)
-	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
+	//Disabled to ensure the objectMeta from support bundle is honored while importing the object
+	//allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionTimestamp(), oldMeta.GetDeletionTimestamp(), fldPath.Child("deletionTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionGracePeriodSeconds(), oldMeta.GetDeletionGracePeriodSeconds(), fldPath.Child("deletionGracePeriodSeconds"))...)
 

--- a/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -25,7 +25,7 @@ import (
 
 // WipeObjectMetaSystemFields erases fields that are managed by the system on ObjectMeta.
 func WipeObjectMetaSystemFields(meta metav1.Object) {
-	meta.SetCreationTimestamp(metav1.Time{})
+	//meta.SetCreationTimestamp(metav1.Time{})
 	meta.SetUID("")
 	meta.SetDeletionTimestamp(nil)
 	meta.SetDeletionGracePeriodSeconds(nil)
@@ -34,7 +34,9 @@ func WipeObjectMetaSystemFields(meta metav1.Object) {
 
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
 func FillObjectMetaSystemFields(meta metav1.Object) {
-	meta.SetCreationTimestamp(metav1.Now())
+	if meta.GetCreationTimestamp().String() == "" {
+		meta.SetCreationTimestamp(metav1.Now())
+	}
 	meta.SetUID(uuid.NewUUID())
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
@@ -438,6 +438,8 @@ func LogLocation(
 	if err != nil {
 		return nil, nil, err
 	}
+	//patch to allow the node to point to localhost to ensure virtual kubelet can return logs
+	nodeInfo.Hostname = "localhost"
 	params := url.Values{}
 	if opts.Follow {
 		params.Add("follow", "true")


### PR DESCRIPTION
PR reverses some of the vendoring changes from previous PR: https://github.com/rancher/support-bundle-kit/pull/111 to ensure original object timestamps and honoured and log streaming works.