### PR TITLE
improve error reporting

### DIFF
--- a/pkg/manager/cluster.go
+++ b/pkg/manager/cluster.go
@@ -59,7 +59,7 @@ func (c *Cluster) GenerateClusterBundle(bundleDir string) (string, error) {
 
 	errLog, err := os.Create(filepath.Join(bundleDir, "bundleGenerationError.log"))
 	if err != nil {
-		logrus.Errorf("Failed to create bundle generation log")
+		logrus.Errorf("Failed to create bundle generation log: %v", err)
 		return "", err
 	}
 	defer errLog.Close()

--- a/pkg/manager/collectors/cluster.go
+++ b/pkg/manager/collectors/cluster.go
@@ -26,7 +26,7 @@ func (module clusterModule) generateYAMLs() {
 	objs, err := module.c.discovery.ResourcesForCluster(module.toObj, module.c.exclude, module.c.errorLog)
 
 	if err != nil {
-		logrus.Error("Unable to fetch cluster resources")
+		logrus.Errorf("Unable to fetch cluster resources: %v", err)
 		return
 	}
 

--- a/pkg/manager/collectors/default.go
+++ b/pkg/manager/collectors/default.go
@@ -56,7 +56,7 @@ func (module defaultModule) generateDiscoveredNamespacedYAMLs(namespace string, 
 	objs, err := module.c.discovery.ResourcesForNamespace(module.toObj, namespace, module.c.exclude, errLog)
 
 	if err != nil {
-		logrus.Error("Unable to fetch namespaced resources")
+		logrus.Errorf("Unable to fetch namespaced resources: %v", err)
 		return
 	}
 

--- a/pkg/manager/collectors/harvester.go
+++ b/pkg/manager/collectors/harvester.go
@@ -33,7 +33,7 @@ func (module harvesterModule) generateYAMLs() {
 		objs, err := module.c.discovery.SpecificResourcesForNamespace(module.toObj, module.name, namespace, resourceLists, module.c.errorLog)
 
 		if err != nil {
-			logrus.Error("Unable to fetch namespaced resources")
+			logrus.Errorf("Unable to fetch namespaced resources: %v", err)
 			return
 		}
 
@@ -48,7 +48,7 @@ func (module harvesterModule) generateYAMLs() {
 	objs, err := module.c.discovery.ResourcesForCluster(module.toClusterObj, module.skipClusterObjects, module.c.errorLog)
 
 	if err != nil {
-		logrus.Error("Unable to fetch cluster scoped resources")
+		logrus.Errorf("Unable to fetch cluster scoped resources: %v", err)
 		return
 	}
 


### PR DESCRIPTION
the collectors in certain scenarios do not report the actual error encountered when connecting to the apiserver.

the PR attempts to add more error info in the logs.