### PR TITLE
move supportconfig to scc folder instead logs

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,9 +11,9 @@ RUN zypper -n install ca-certificates awk lsb-release rsync docker containerd
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.55.2;
 
 # The docker version in dapper is too old to have buildx. Install it manually.
-RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.13.1/buildx-v0.13.1.linux-${ARCH} -o buildx-v0.13.1.linux-${ARCH} && \
-    chmod +x buildx-v0.13.1.linux-${ARCH} && \
-    mv buildx-v0.13.1.linux-${ARCH} /usr/local/bin/buildx
+RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.14.1/buildx-v0.14.1.linux-${ARCH} -o buildx-v0.14.1.linux-${ARCH} && \
+    chmod +x buildx-v0.14.1.linux-${ARCH} && \
+    mv buildx-v0.14.1.linux-${ARCH} /usr/local/bin/buildx
 
 # -- for dapper
 ENV DAPPER_RUN_ARGS --privileged --network host -v /run/containerd/containerd.sock:/run/containerd/containerd.sock

--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -86,13 +86,18 @@ collect_etc ${BUNDLE_DIR}/configs/etc
 ###############################################################################
 # collect logs
 ###############################################################################
-mkdir -p logs
-cd logs
+mkdir -p scc
 
 # Generate supportconfig from node
 chroot $HOST_PATH /sbin/supportconfig -c -m -B supportconfig_$SUPPORT_BUNDLE_NODE_NAME \
     -i BOOT,DAEMONS,ETC,ISCSI,MEM,MOD,NTP,SMART,DISK,pharvester_plugin_rke2,pharvester_plugin_console
-mv $HOST_PATH/var/log/scc_supportconfig_$SUPPORT_BUNDLE_NODE_NAME.txz .
+mv $HOST_PATH/var/log/scc_supportconfig_$SUPPORT_BUNDLE_NODE_NAME.txz ./scc
+
+###############################################################################
+# collect logs
+###############################################################################
+mkdir -p logs
+cd logs
 
 chroot $HOST_PATH /usr/bin/journalctl -k > kernel.log
 # also collect logs of previous two boots


### PR DESCRIPTION
This PR mainly moves the supportconfig file to the specific folder to clarify it.

Related issue: https://github.com/harvester/harvester/issues/6016