### PR TITLE
Build: upgrade base image to 15.6

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
Fix CVE vulnerability `SUSE-SU-2024:2302-1`.

Ref longhorn/longhorn#8976