### PR TITLE
fix: shouldn't set error in optional phases

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,11 +1,15 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/rancher/support-bundle-kit/pkg/types"
 )
 
 func TestParseToleration(t *testing.T) {
@@ -69,5 +73,108 @@ func TestParseToleration(t *testing.T) {
 		if test.expectError && err == nil {
 			t.Errorf("unexpected error: %v", err)
 		}
+	}
+}
+
+func TestRunAllPhases(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredPhases   []RunPhase
+		optionalPhases   []RunPhase
+		postPhases       []RunPhase
+		expectedError    bool
+		expectedProgress int
+	}{
+		{
+			name: "All pass",
+			requiredPhases: []RunPhase{
+				{Name: types.ManagerPhaseInit, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseClusterBundle, Run: func() error { return nil }},
+			},
+			optionalPhases: []RunPhase{
+				{Name: types.ManagerPhasePrometheusBundle, Run: func() error { return nil }},
+			},
+			postPhases: []RunPhase{
+				{Name: types.ManagerPhasePackaging, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseDone, Run: func() error { return nil }},
+			},
+			expectedError:    false,
+			expectedProgress: 100,
+		},
+		{
+			name: "First Required phase error",
+			requiredPhases: []RunPhase{
+				{Name: types.ManagerPhaseInit, Run: func() error { return errors.New("required phase error") }},
+				{Name: types.ManagerPhaseClusterBundle, Run: func() error { return nil }},
+			},
+			optionalPhases: []RunPhase{
+				{Name: types.ManagerPhasePrometheusBundle, Run: func() error { return nil }},
+			},
+			postPhases: []RunPhase{
+				{Name: types.ManagerPhasePackaging, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseDone, Run: func() error { return nil }},
+			},
+			expectedError:    true,
+			expectedProgress: 0,
+		},
+		{
+			name: "Second Required phase error",
+			requiredPhases: []RunPhase{
+				{Name: types.ManagerPhaseInit, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseClusterBundle, Run: func() error { return errors.New("required phase error") }},
+			},
+			optionalPhases: []RunPhase{
+				{Name: types.ManagerPhasePrometheusBundle, Run: func() error { return nil }},
+			},
+			postPhases: []RunPhase{
+				{Name: types.ManagerPhasePackaging, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseDone, Run: func() error { return nil }},
+			},
+			expectedError:    true,
+			expectedProgress: 20,
+		},
+		{
+			name: "Optional phase error",
+			requiredPhases: []RunPhase{
+				{Name: types.ManagerPhaseInit, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseClusterBundle, Run: func() error { return nil }},
+			},
+			optionalPhases: []RunPhase{
+				{Name: types.ManagerPhasePrometheusBundle, Run: func() error { return errors.New("optional phase error") }},
+			},
+			postPhases: []RunPhase{
+				{Name: types.ManagerPhasePackaging, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseDone, Run: func() error { return nil }},
+			},
+			expectedError:    false,
+			expectedProgress: 100,
+		},
+		{
+			name: "Final Post phase error",
+			requiredPhases: []RunPhase{
+				{Name: types.ManagerPhaseInit, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseClusterBundle, Run: func() error { return nil }},
+			},
+			optionalPhases: []RunPhase{
+				{Name: types.ManagerPhasePrometheusBundle, Run: func() error { return nil }},
+			},
+			postPhases: []RunPhase{
+				{Name: types.ManagerPhasePackaging, Run: func() error { return nil }},
+				{Name: types.ManagerPhaseDone, Run: func() error { return errors.New("post phase error") }},
+			},
+			expectedError:    true,
+			expectedProgress: 80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &SupportBundleManager{
+				status: ManagerStatus{},
+			}
+			m.runAllPhases(tt.requiredPhases, tt.optionalPhases, tt.postPhases)
+			assert.Equal(t, tt.expectedError, m.status.Error, "expected error %v, got %v")
+			assert.Equal(t, tt.expectedProgress, m.status.Progress, "expected progress %v, got %v")
+		})
 	}
 }


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/6898

1. Passing a flag decides if set error or not.
2. `progressCount` should increase when getting error in optional phases