### PR TITLE
Simulator: speed up bundle loading

### DIFF
--- a/pkg/simulator/apiserver/apiserver_test.go
+++ b/pkg/simulator/apiserver/apiserver_test.go
@@ -2,13 +2,14 @@ package apiserver
 
 import (
 	"context"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/certs"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/etcd"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/rancher/support-bundle-kit/pkg/simulator/certs"
+	"github.com/rancher/support-bundle-kit/pkg/simulator/etcd"
 )
 
 func TestRunAPIServer(t *testing.T) {
@@ -22,7 +23,7 @@ func TestRunAPIServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	a := APIServerConfig{}
+	a := NewAPIServerConfig(DefaultClientQPS, DefaultClientBurst)
 
 	generatedCerts, err := certs.GenerateCerts([]string{"localhost", "127.0.0.1"}, dir)
 	if err != nil {

--- a/pkg/simulator/crd/crd_test.go
+++ b/pkg/simulator/crd/crd_test.go
@@ -2,15 +2,17 @@ package crd
 
 import (
 	"context"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/apiserver"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/certs"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/etcd"
-	"golang.org/x/sync/errgroup"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rancher/support-bundle-kit/pkg/simulator/apiserver"
+	"github.com/rancher/support-bundle-kit/pkg/simulator/certs"
+	"github.com/rancher/support-bundle-kit/pkg/simulator/etcd"
 )
 
 func TestWriteFiles(t *testing.T) {
@@ -36,7 +38,7 @@ func TestInstallCRD(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	a := apiserver.APIServerConfig{}
+	a := apiserver.NewAPIServerConfig(apiserver.DefaultClientQPS, apiserver.DefaultClientBurst)
 
 	generatedCerts, err := certs.GenerateCerts([]string{"localhost", "127.0.0.1"}, dir)
 	if err != nil {

--- a/pkg/simulator/objects/apply.go
+++ b/pkg/simulator/objects/apply.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/restmapper"
 
 	supportbundlekit "github.com/rancher/support-bundle-kit/pkg/simulator/apis/supportbundlekit.io/v1"
+	"github.com/rancher/support-bundle-kit/pkg/simulator/crd"
 )
 
 type ProgressHandler func(int, int)
@@ -89,6 +90,13 @@ func (o *ObjectManager) CreateUnstructuredClusterObjects() error {
 	}
 
 	progressMgr := NewProgressManager("Step 1/4: Cluster CRDs")
+
+	// add simulator CRDs
+	simCRDs, err := crd.Objects(false)
+	if err != nil {
+		return fmt.Errorf("error generating Simulator CRD objects: %v", err)
+	}
+	crds = append(crds, simCRDs...)
 
 	// apply CRDs first
 	err = o.ApplyObjects(crds, false, nil, progressMgr.progress)

--- a/pkg/simulator/objects/process_node_zips.go
+++ b/pkg/simulator/objects/process_node_zips.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	bundlekit "github.com/rancher/support-bundle-kit/pkg/simulator/apis/supportbundlekit.io/v1"
-	"github.com/rancher/support-bundle-kit/pkg/simulator/crd"
 )
 
 const (
@@ -94,11 +93,6 @@ func (o *ObjectManager) ProcessNodeZipObjects() (noStatusObjs []runtime.Object, 
 		return noStatusObjs, withStatusObjs, fmt.Errorf("error evaulating absolute path to node dirs: %v", err)
 	}
 
-	crdObjects, err := crd.Objects(false)
-	if err != nil {
-		return noStatusObjs, withStatusObjs, fmt.Errorf("error generating CRD objects: %v", err)
-	}
-
 	nodeZipList, err := generateNodeZipList(bundleAbsPath)
 
 	if err != nil {
@@ -113,8 +107,6 @@ func (o *ObjectManager) ProcessNodeZipObjects() (noStatusObjs []runtime.Object, 
 	noStatusObjs = []runtime.Object{
 		&NodeInfoNS, &NodeInfoSASecret, &NodeInfoSA,
 	}
-
-	noStatusObjs = append(noStatusObjs, crdObjects...)
 
 	for _, v := range podList {
 		withStatusObjs = append(withStatusObjs, v)

--- a/pkg/simulator/objects/progress.go
+++ b/pkg/simulator/objects/progress.go
@@ -25,6 +25,13 @@ func (p *ProgressManager) progress(current, total int) {
 
 	if current == total {
 		fmt.Printf("\n")
-		fmt.Printf("Time to load all objects: %s seconds\n\n", time.Since(p.start))
+		elapsed := time.Since(p.start)
+		elapsedInSecond := int(elapsed.Seconds())
+
+		objsPerSecond := total
+		if elapsedInSecond != 0 {
+			objsPerSecond = total / elapsedInSecond
+		}
+		fmt.Printf("Time to load all objects: %s seconds. (%d objects/s)\n\n", elapsed, objsPerSecond)
 	}
 }


### PR DESCRIPTION
Related to my SUSE hack week project: https://hackweek.opensuse.org/projects/sbk-simulator-enhancements

Relax the client-side throttling to speed up bundle loading time.

The default rate limiter has Burst set to 10 and QPS set to 5, increasing the number (technically no limitation) to boost the bundle loading time.
I tested loading a customer bundle, the loading time decreased from **46min38s** to **1min20s**.

Todo:
- [x] Wait for CRD creation.
    - Add a 5-second sleep before loading speed. This should be good for most case and we can improve this later.
- [x] What's the cost? Should we set an upper bound limitation value?
    - Observation: the processing speed is around 60~80 objects per second on two bare-metal machines.
    - Setting the burst/QPS to 100 should be reasonable.
    - Add flags so the values are tuneable.
- [x] Correctness?
    - CI pass and it looks OK for most tests.