### PR TITLE
support bundle: add node network information

### DIFF
--- a/hack/collector-harvester
+++ b/hack/collector-harvester
@@ -91,7 +91,7 @@ mkdir -p scc
 
 # Generate supportconfig from node
 chroot $HOST_PATH /sbin/supportconfig -c -m -B supportconfig_$SUPPORT_BUNDLE_NODE_NAME \
-    -i BOOT,DAEMONS,ETC,ISCSI,MEM,MOD,NTP,SMART,DISK,pharvester_plugin_rke2,pharvester_plugin_console
+    -i BOOT,DAEMONS,ETC,ISCSI,MEM,MOD,NET,NTP,SMART,DISK,pharvester_plugin_rke2,pharvester_plugin_console
 mv $HOST_PATH/var/log/scc_supportconfig_$SUPPORT_BUNDLE_NODE_NAME.txz ./scc
 
 ###############################################################################


### PR DESCRIPTION
Add node network information to supportbundle. The supportbundle already collects a lot of configs from the node. This adds the network config as well, which aids when debugging network issues.

related-to: https://github.com/harvester/harvester/issues/7714