### PR TITLE
Fix control characters are not allowed under MacOS

### DIFF
--- a/pkg/simulator/objects/objects.go
+++ b/pkg/simulator/objects/objects.go
@@ -30,7 +30,7 @@ func GenerateClusterScopedRuntimeObjects(path string) (crd []runtime.Object, clu
 			return err
 		}
 
-		if !info.IsDir() {
+		if !info.IsDir() && strings.HasSuffix(path, ".yaml") {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return err
@@ -86,7 +86,7 @@ func GenerateNamespacedRuntimeObjects(path string) (nonpods []runtime.Object, po
 			return err
 		}
 
-		if !info.IsDir() {
+		if !info.IsDir() && strings.HasSuffix(path, ".yaml") {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return err
@@ -134,11 +134,14 @@ func GenerateNamespacedRuntimeObjects(path string) (nonpods []runtime.Object, po
 func GenerateObjects(file string) (obj []runtime.Object, err error) {
 	content, err := os.ReadFile(file)
 	if err != nil {
-		return obj, err
+		return obj, fmt.Errorf("error reading file %s: %v", file, err)
 	}
 
 	obj, err = yaml.ToObjects(bytes.NewReader(content))
-	return obj, err
+	if err != nil {
+		return obj, fmt.Errorf("error generating objects from file %s: %v", file, err)
+	}
+	return obj, nil
 }
 
 func GenerateUnstructuredObjects(file string) (objs []*unstructured.Unstructured, err error) {


### PR DESCRIPTION
When loading a SB in on macOS, I encountered the following error:

```sh
FATA[0034] Error loading namespacedobjects yaml: control characters are not allowed
```

The issue was caused by `.DS_Store` files interfering with the simulator, as it's not in YAML format and triggered the `control characters are not allowed` error. This PR resolves the issue by filtering out all files that don't have a .yaml suffix when loading objects. It also improves the `GenerateObjects` method by adding a more explicit error message.