### PR TITLE
patch vendor files for k8s v1.33

### DIFF
--- a/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -252,7 +252,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetName(), oldMeta.GetName(), fldPath.Child("name"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetNamespace(), oldMeta.GetNamespace(), fldPath.Child("namespace"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetUID(), oldMeta.GetUID(), fldPath.Child("uid"))...)
-	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
+	// allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionTimestamp(), oldMeta.GetDeletionTimestamp(), fldPath.Child("deletionTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionGracePeriodSeconds(), oldMeta.GetDeletionGracePeriodSeconds(), fldPath.Child("deletionGracePeriodSeconds"))...)
 

--- a/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -28,7 +28,7 @@ var metav1Now = func() metav1.Time { return metav1.Now() }
 
 // WipeObjectMetaSystemFields erases fields that are managed by the system on ObjectMeta.
 func WipeObjectMetaSystemFields(meta metav1.Object) {
-	meta.SetCreationTimestamp(metav1.Time{})
+	//meta.SetCreationTimestamp(metav1.Time{})
 	meta.SetUID("")
 	meta.SetDeletionTimestamp(nil)
 	meta.SetDeletionGracePeriodSeconds(nil)
@@ -37,6 +37,9 @@ func WipeObjectMetaSystemFields(meta metav1.Object) {
 
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
 func FillObjectMetaSystemFields(meta metav1.Object) {
+	if meta.GetCreationTimestamp().String() == "" {
+		meta.SetCreationTimestamp(metav1.Now())
+	}
 	meta.SetCreationTimestamp(metav1Now())
 	meta.SetUID(uuid.NewUUID())
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
@@ -618,6 +618,10 @@ func LogLocation(
 	if err != nil {
 		return nil, nil, err
 	}
+
+	//patch to allow the node to point to localhost to ensure virtual kubelet can return logs
+	nodeInfo.Hostname = "localhost"
+
 	params := url.Values{}
 	if opts.Follow {
 		params.Add("follow", "true")


### PR DESCRIPTION
Patch vendor files for k8s v1.33 to ensure creationtimestamp and log routing works as expected.