### PR TITLE
fix: build failure

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,12 +3,14 @@ FROM registry.suse.com/bci/golang:1.25.9
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
+ENV GOLANGCI_LINT_VERSION=v2.11.4
+
 # -- for make rules
 ## install docker client
 RUN zypper -n install ca-certificates awk lsb-release rsync docker containerd
 
 # Install golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" $GOLANGCI_LINT_VERSION
 
 # The docker version in dapper is too old to have buildx. Install it manually.
 RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.14.1/buildx-v0.14.1.linux-${ARCH} -o buildx-v0.14.1.linux-${ARCH} && \


### PR DESCRIPTION
```
golangci/golangci-lint info checking GitHub for tag 'latest'
golangci/golangci-lint info found version: 2.12.2 for v2.12.2/linux/amd64
golangci/golangci-lint err hash_sha256_verify checksum for '/tmp/tmp.GUV9JHU53E/golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
fd3a137c7e722128143cc8932bcaa00bc73e10adadee18bdb0893453edb2c137 vs 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
```

longhorn/longhorn#13022