### PR TITLE
[Docs] Add KUBECONFIG export step to kubectl instructions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,11 @@ This will trigger the bootstrap of the simulator components and load the content
 
 For `kubectl logs` to work, the `--bundle-path` should point to the correct bundle path, the default is `.`
 
-The state of the simulator is stored in `$HOME/.sim`, where the users can find an `admin.kubeconfig`
+The state of the simulator is stored in `$HOME/.sim`, where the users can find an `admin.kubeconfig`. Run the following command to set the `KUBECONFIG` environment variable.
+
+```bash
+export KUBECONFIG=$HOME/.sim/admin.kubeconfig
+```
 
 This can now be used to interact with the cluster.
 


### PR DESCRIPTION
This PR adds an explicit `export KUBECONFIG=~/.sim/admin.kubeconfig` step before running the kubectl commands in the documentation.

**Context:**
As raised in issue #138 , while this might be obvious to experienced users, beginners often struggle with:
- Understanding how kubectl locates the kubeconfig file
- The difference between default `~/.kube/config` and custom config files
- The correct syntax for setting the KUBECONFIG environment variable

Currently, users have to search Slack or other channels to figure this out. Adding this step will save time and reduce confusion for new users.