### PR TITLE
[Fix] Prevent simulator crash when nodes directory is missing

### DIFF
--- a/pkg/simulator/objects/process_node_zips.go
+++ b/pkg/simulator/objects/process_node_zips.go
@@ -123,6 +123,11 @@ func generateNodeZipList(bundleAbsPath string) ([]string, error) {
 	var nodeZipList []string
 	err := filepath.Walk(filepath.Join(bundleAbsPath, DefaultNodeDir), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+                logrus.Warnf("Path %q does not exist, skipping node zip processing", path)
+                return nil
+            }
+			
 			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
 			return err
 		}


### PR DESCRIPTION
This PR fixes a fatal crash that occurs when the simulator attempts to load a support bundle generated in standalone mode without a `nodes/` directory.

Currently, if the node collection triggers are omitted from the manifest, the bundle generates correctly but the simulator strictly expects `nodes/` to exist and crashes via `logrus.Fatalf` during `filepath.Walk`.

### Proposed Changes
- Added an `os.IsNotExist` check in `pkg/simulator/objects/process_node_zips.go` before attempting to load node zip objects.
- If the directory is missing, the simulator now logs an info message and gracefully proceeds to load the remaining resources.

Fixes #183 

### Testing
- [x] Generated a standalone bundle without node collection triggers.
- [x] Ran `simulator` against the bundle.
- [x] Verified the simulator boots successfully and serves cluster/namespaced objects without crashing.