### PR TITLE
fix(integration): speedup objects loading time

### DIFF
--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -58,6 +58,8 @@ var _ = BeforeSuite(func(done Done) {
 	samplePodSpec = filepath.Join(samplesPath, "/yamls/namespaced/harvester-system/v1/pods.yaml")
 
 	By("setting up test cluster")
+	a = apiserver.NewAPIServerConfig(apiserver.DefaultClientQPS, apiserver.DefaultClientBurst)
+
 	certificates, err := certs.GenerateCerts([]string{"localhost", "127.0.0.1"},
 		dir)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Without the QPS and Burst settings, the default values are insanely low. Increase the values to dramatically reduce the objects loading time during integration test. This is similar to the fix in https://github.com/rancher/support-bundle-kit/pull/127.

The `TestSim` test time changes from

```
--- PASS: TestSim (1173.31s)
```

to

```
--- PASS: TestSim (78.02s)

```