### PR TITLE
chore: update ci with cron schedule and manual triggers

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - release/v*
+  schedule:
+    - cron: "30 2 * * *" # daily at 02:30 AM UTC
+  workflow_dispatch:
 
 jobs:
   call-dapper-build:


### PR DESCRIPTION
## Changes

this pr updates ci `master` build with cron schedule and manual triggers. this allows the image to be rebuilt daily so that we can keep up with security patches in go stdlib, yq etc.