### PR TITLE
[CI] Add macOS (Darwin) build support and release artifacts

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && fromJSON(inputs.release) }}
         run: |
           cd dist/artifacts
-          for arch in amd64 arm64; do
+          for arch in amd64 arm64 darwin-arm64; do
             rm -f sha256sum-$arch.txt && touch sha256sum-$arch.txt
             if [ -e support-bundle-kit-$arch ]; then
               tar zcf support-bundle-kit-$arch.tar.gz support-bundle-kit-$arch
@@ -81,5 +81,7 @@ jobs:
           fi
           gh release upload ${{ github.ref_name }} dist/artifacts/support-bundle-kit-amd64.tar.gz
           gh release upload ${{ github.ref_name }} dist/artifacts/support-bundle-kit-arm64.tar.gz
+          gh release upload ${{ github.ref_name }} dist/artifacts/support-bundle-kit-darwin-arm64.tar.gz
           gh release upload ${{ github.ref_name }} dist/artifacts/sha256sum-amd64.txt
           gh release upload ${{ github.ref_name }} dist/artifacts/sha256sum-arm64.txt
+          gh release upload ${{ github.ref_name }} dist/artifacts/sha256sum-darwin-arm64.txt

--- a/scripts/build
+++ b/scripts/build
@@ -13,6 +13,7 @@ LINKFLAGS="-X github.com/rancher/support-bundle-kit/cmd.AppVersion=$VERSION
 
 CGO_ENABLED=0 GOARCH=amd64 GO111MODULE=on go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -mod=vendor -o bin/support-bundle-kit-amd64
 CGO_ENABLED=0 GOARCH=arm64 GO111MODULE=on go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -mod=vendor -o bin/support-bundle-kit-arm64
+CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 GO111MODULE=on go build -ldflags "$LINKFLAGS" -mod=vendor -o bin/support-bundle-kit-darwin-arm64
 
 # non-go scripts
 cp hack/* bin


### PR DESCRIPTION
### Description
This PR adds official macOS build support to support-bundle-kit. Previously, macOS binaries were not included in the release pipeline, limiting users on Darwin-based systems from using the tool without building from source.

### What's Changed
- Build matrix update: Added GOOS=darwin with arm64 architectures to the Go build step
- Release workflow: Updated the GitHub Actions release pipeline to include macOS binaries as release artifacts
- Artifact naming: macOS binaries will now be published alongside existing Linux and Windows builds

### Why This Matters
- Enables native macOS users to install and run support-bundle-kit without manual compilation
- Supports Apple Silicon (arm64) Macs
- This enables the cross-platform support

Testing
- [x] Build verified locally for darwin/arm64
- [x] Release workflow tested on a dry run
- [x] Binaries execute correctly on macOS environment