### PR TITLE
fix: build cache volume is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 # ---- base ----
 FROM builder AS base
+ENV HOME=/go/src/github.com/rancher/support-bundle-kit
 WORKDIR /go/src/github.com/rancher/support-bundle-kit
 
 # to exclude some files, add them in .dockerignore


### PR DESCRIPTION
Without setting the HOME variable, the cache is default to /root/.cache/go-build. Setting the HOME variable to ensure the cache mounts are correct.

```
RUN --mount=type=cache,target=/go/pkg/mod,id=support-bundle-kit-go-mod-${MK_REPO_ID} \
    --mount=type=cache,target=/go/src/github.com/rancher/support-bundle-kit/.cache/go-build,id=support-bundle-kit-go-build-${MK_REPO_ID} \
    ./scripts/build
```

A local build with the cache should complete very quickly with the patch.