### PR TITLE
build: enforce simulator vendor patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DOCKER_BUILD = docker build $(MK_DOCKER_PULL) \
 	--build-arg MK_HOST_ARCH \
 	-f $(ROOT)/Dockerfile $(ROOT)
 
-.PHONY: build ci generate package test validate
+.PHONY: build ci generate package simulator-vendor-check simulator-vendor-patch test validate
 
 
 # ---- Directories ----
@@ -71,6 +71,16 @@ $(ROOT)/bin:
 gen-version-env:
 	$(BANNER)
 	@bash $(ROOT)/scripts/version > /dev/null
+
+
+# ---- Simulator vendor patch ----
+simulator-vendor-patch:
+	$(BANNER)
+	@$(ROOT)/scripts/simulator-vendor apply
+
+simulator-vendor-check:
+	$(BANNER)
+	@$(ROOT)/scripts/simulator-vendor check
 
 
 # ---- Compile support-bundle-kit binaries ----
@@ -111,4 +121,4 @@ clean:
 
 default: build package
 
-ci: build validate test package
+ci: simulator-vendor-check build validate test package

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,10 +1,12 @@
 # Development instructions
 
-The support-bundle-kit simulator functionality tweaks a few objects in the upstream k8s.io code based which is available in the vendor directory.
+The support-bundle-kit simulator patches a few upstream Kubernetes files in the vendor directory. The patch is stored in `patches/simulator.patch`.
 
-The following instructions need to be followed to ensure that vendoring updates refactor these changes.
+After changing Go dependencies, run `go mod vendor` followed by `make simulator-vendor-patch`, then commit the patched vendor files. If an upstream change makes a patch hunk incompatible, the target fails and asks for the patch to be refreshed.
 
-We have patched a few items in the code to allow the `simulator` functionality:
+To refresh the patch, start from the output of `go mod vendor`, make the simulator changes described below, and regenerate `patches/simulator.patch` from the vendor diff. Run `make simulator-vendor-check` to verify that the committed vendor directory contains the patch. The `ci` target runs this check before building and testing.
+
+The patch contains the following changes required by the `simulator` functionality:
 
 ## creationTimestamp support
 To ensure that the `creationTimestamp` is honored from the exported objects we have disabled the validation on `creationTimestamp` the following changes have been made:

--- a/patches/simulator.patch
+++ b/patches/simulator.patch
@@ -1,0 +1,50 @@
+diff --git a/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go b/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+index 839fcbc2..66e216cd 100644
+--- a/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
++++ b/vendor/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+@@ -330,7 +330,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
+ 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetName(), oldMeta.GetName(), fldPath.Child("name"))...)
+ 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetNamespace(), oldMeta.GetNamespace(), fldPath.Child("namespace"))...)
+ 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetUID(), oldMeta.GetUID(), fldPath.Child("uid"))...)
+-	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
++	//allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
+ 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionTimestamp(), oldMeta.GetDeletionTimestamp(), fldPath.Child("deletionTimestamp"))...)
+ 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionGracePeriodSeconds(), oldMeta.GetDeletionGracePeriodSeconds(), fldPath.Child("deletionGracePeriodSeconds"))...)
+ 
+diff --git a/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go b/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
+index 47f7f83b..3f16eec9 100644
+--- a/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
++++ b/vendor/k8s.io/apiserver/pkg/registry/rest/meta.go
+@@ -28,7 +28,7 @@ var metav1Now = metav1.Now
+ 
+ // WipeObjectMetaSystemFields erases fields that are managed by the system on ObjectMeta.
+ func WipeObjectMetaSystemFields(meta metav1.Object) {
+-	meta.SetCreationTimestamp(metav1.Time{})
++	//meta.SetCreationTimestamp(metav1.Time{})
+ 	meta.SetUID("")
+ 	meta.SetDeletionTimestamp(nil)
+ 	meta.SetDeletionGracePeriodSeconds(nil)
+@@ -37,7 +37,9 @@ func WipeObjectMetaSystemFields(meta metav1.Object) {
+ 
+ // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
+ func FillObjectMetaSystemFields(meta metav1.Object) {
+-	meta.SetCreationTimestamp(metav1Now())
++	if meta.GetCreationTimestamp().String() == "" {
++		meta.SetCreationTimestamp(metav1.Now())
++	}
+ 	meta.SetUID(uuid.NewUUID())
+ }
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
+index a77ad051..748bcbf7 100644
+--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
++++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/strategy.go
+@@ -631,6 +631,8 @@ func LogLocation(
+ 	if err != nil {
+ 		return nil, nil, err
+ 	}
++	nodeInfo.Hostname = "localhost"
++
+ 	params := url.Values{}
+ 	if opts.Follow {
+ 		params.Add("follow", "true")

--- a/scripts/simulator-vendor
+++ b/scripts/simulator-vendor
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SIMULATOR_VENDOR_PATCH="${ROOT}/patches/simulator.patch"
+
+cd "${ROOT}"
+
+case "${1:-}" in
+apply)
+	if git apply --reverse --check "${SIMULATOR_VENDOR_PATCH}" >/dev/null 2>&1; then
+		echo "Simulator vendor patch is already applied"
+	elif git apply --check "${SIMULATOR_VENDOR_PATCH}"; then
+		git apply "${SIMULATOR_VENDOR_PATCH}"
+		echo "Simulator vendor patch is applied"
+	else
+		echo "ERROR: Simulator vendor patch no longer applies. Refresh ${SIMULATOR_VENDOR_PATCH} after updating dependencies." >&2
+		exit 1
+	fi
+	;;
+check)
+	if ! git apply --reverse --check "${SIMULATOR_VENDOR_PATCH}" >/dev/null 2>&1; then
+		echo "ERROR: Simulator vendor patch is not applied. Run 'make simulator-vendor-patch' and commit the vendor changes." >&2
+		exit 1
+	fi
+	;;
+*)
+	echo "Usage: $0 {apply|check}" >&2
+	exit 2
+	;;
+esac


### PR DESCRIPTION
Add Make targets backed by a script to apply and verify the simulator-specific Kubernetes vendor patch.
Run the verification as part of CI so dependency updates cannot silently remove the required simulator behavior.

This ensure we don't forget the apply the hack when vendor changes.