### PR TITLE
Publish images via harvester-actions

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,15 +1,14 @@
 name: Tag Build and Publish
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [published]
 
 jobs:
   call-dapper-build:
     uses: ./.github/workflows/template-build.yml
     with:
-      release-tag-name: ${{ github.ref_name }}
+      release-tag-name: ${{ github.event.release.tag_name }}
       push: true
       release: true
     secrets: inherit

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
 
+env:
+  PLATFORMS: linux/amd64,linux/arm64
+  imageName: support-bundle-kit
+
 jobs:
   dapper-build:
     runs-on: ubuntu-latest
@@ -31,33 +35,70 @@ jobs:
       - name: Run dapper
         run: make ci
 
-      - name: Read some Secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-        if: ${{ inputs.push == true }}
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        if: ${{ inputs.push == true }}
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-
       - name: Docker Build
+        if: ${{ inputs.push == false }}
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           provenance: false
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           file: package/Dockerfile
-          push: ${{ inputs.push }}
-          tags: rancher/support-bundle-kit:${{ inputs.release-tag-name }}
+          push: false
+          tags: ${{ env.imageName }}:${{ inputs.release-tag-name }}
+
+      - name: Login to Docker Hub
+        id: login-docker
+        if: ${{ inputs.push == true }}
+        uses: harvester/harvester-actions/actions/login-docker-hub@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+
+      - name: Publish public ${{ env.imageName }} image
+        if: ${{ inputs.push == true }}
+        uses: harvester/harvester-actions/actions/publish-public-image@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ inputs.release-tag-name }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-docker.outputs.registry }}
+          repository: ${{ steps.login-docker.outputs.repository }}
+
+      - name: Login to Staging Registry
+        id: login-staging
+        if: ${{ inputs.push == true && inputs.release == false }}
+        uses: harvester/harvester-actions/actions/login-staging-registry@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+
+      - name: Publish staging ${{ env.imageName }} image
+        if: ${{ inputs.push == true && inputs.release == false }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ inputs.release-tag-name }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-staging.outputs.registry }}
+          repository: ${{ steps.login-staging.outputs.repository }}
+
+      - name: Login to Prime Registry
+        id: login-prime
+        if: ${{ inputs.push == true && inputs.release == true }}
+        uses: harvester/harvester-actions/actions/login-prime-registry@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+
+      - name: Publish prime ${{ env.imageName }} image
+        if: ${{ inputs.push == true && inputs.release == true }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@f5246cd8d423922ea55141991155f4b05f665bd5 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ inputs.release-tag-name }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-prime.outputs.registry }}
+          repository: ${{ steps.login-prime.outputs.repository }}
 
       - name: Prepare artifacts for the release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && fromJSON(inputs.release) }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.release }}
         run: |
           cd dist/artifacts
           for arch in amd64 arm64 darwin-arm64; do
@@ -67,10 +108,10 @@ jobs:
               sha256sum support-bundle-kit-$arch.tar.gz > sha256sum-$arch.txt
             fi
           done
-      
+
 
       - name: Publish artifacts to the release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && fromJSON(inputs.release) }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.release }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Use the shared harvester/harvester-actions actions so images are conditionally published to docker.io, the staging registry, and the prime registry.
      - Branch merge: push to the public and staging registries.
      - Tag (v*): push to the public registry/prime registries.

